### PR TITLE
Add L21+L1 norm and proximal with tests

### DIFF
--- a/pyproximal/proximal/L21_plus_L1.py
+++ b/pyproximal/proximal/L21_plus_L1.py
@@ -1,0 +1,44 @@
+import numpy as np
+from pyproximal import ProxOperator
+from pyproximal.ProxOperator import _check_tau
+
+
+class L21_plus_L1(ProxOperator):
+    r"""L21 + L1 norm proximal operator.
+
+    Proximal operator of the :math:`L_{2,1} + L_1` mixed-norm [1]_:
+    :math:`\sigma \rho ||\mathbf{X}||_1 + \sigma (1 - \rho) ||\mathbf{X}||_{2,1}`
+
+    Parameters
+    ----------
+    sigma : :obj:`int`, optional
+        Multiplicative coefficient of :math:`L_{2,1} + L_1` mixed-norm
+    rho : :obj:`int`, optional
+        Balancing between sparsity of :math:`L_1` and grouping of :math:`L_{2,1}`
+
+    .. [1] Gramfort, Alexandre, Daniel Strohmeier, Jens Haueisen, Matti Hamalainen,
+        and Matthieu Kowalski. "Functional brain imaging with M/EEG using structured
+        sparsity in time-frequency dictionaries." In Biennial International Conference
+        on Information Processing in Medical Imaging, pp. 600-611. Springer, Berlin,
+        Heidelberg, 2011.
+    """
+
+    def __init__(self, sigma=1.0, rho=0.8):
+        super().__init__(None, False)
+        self.sigma = sigma
+        self.rho = rho
+
+    def __call__(self, x):
+        return self.rho * self.sigma * np.sum(np.abs(x)) + (1 - self.rho) * self.sigma * np.sum(
+            np.sqrt(np.sum(x ** 2, axis=0))
+        )
+
+    @_check_tau
+    def prox(self, x, tau, axis=0):
+        thresh = self.sigma * tau
+        l1 = np.maximum(np.abs(x) - thresh * self.rho, 0)
+        # Axis defines what dimension to perform grouping over
+        aux_l21 = np.sqrt(np.sum(np.maximum(np.abs(x) - thresh * self.rho, 0) ** 2, axis=axis))
+        l21 = np.maximum(1 - thresh * (1 - self.rho) / aux_l21, 0)
+        x = np.nan_to_num(x / np.abs(x)) * l1 * l21
+        return x

--- a/pyproximal/proximal/__init__.py
+++ b/pyproximal/proximal/__init__.py
@@ -17,6 +17,7 @@ The subpackage proximal contains a number of proximal operators:
     L2	                            L2 Norm
     L2Convolve	                    L2 Norm of convolution operator
     L21	                            L2,1 Norm
+    L21_plus_L1	                    L2,1 + L1 mixed-norm
     Huber	                        Huber Norm
     Nuclear                         Nuclear Norm
     NuclearBall                     Nuclear Ball
@@ -35,13 +36,13 @@ from .Euclidean import *
 from .L1 import *
 from .L2 import *
 from .L21 import *
+from .L21_plus_L1 import *
 from .Huber import *
 from .Nuclear import *
 from .Orthogonal import *
 from .VStack import *
 
-
 __all__ = ['Box', 'Simplex', 'Intersection', 'AffineSet', 'Quadratic',
            'Euclidean', 'EuclideanBall', 'L1', 'L1Ball', 'L2', 'L2Convolve',
-           'L21', 'Huber', 'Nuclear', 'NuclearBall', 'Orthogonal', 'VStack',
-           'Nonlinear']
+           'L21', 'L21_plus_L1', 'Huber', 'Nuclear', 'NuclearBall',
+           'Orthogonal', 'VStack', 'Nonlinear']

--- a/pytests/test_norms.py
+++ b/pytests/test_norms.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_array_almost_equal
 
 from pylops.basicoperators import Identity, Diagonal
 from pyproximal.utils import moreau
-from pyproximal.proximal import Box, Euclidean, L2, L1, L21, Huber, Nuclear
+from pyproximal.proximal import Box, Euclidean, L2, L1, L21, L21_plus_L1, Huber, Nuclear
 
 par1 = {'nx': 10, 'sigma': 1., 'dtype': 'float32'}  # even float32
 par2 = {'nx': 11, 'sigma': 2., 'dtype': 'float64'}  # odd float64
@@ -132,6 +132,26 @@ def test_L21(par):
     # prox / dualprox
     tau = 2.
     assert moreau(l21, x, tau)
+
+
+@pytest.mark.parametrize('par', [(par1), (par2)])
+def test_L21_plus_L1(par):
+    """L21 plus L1 norm on 2darray.
+    """
+    l21_plus_l1 = L21_plus_L1(ndim=2, sigma=par['sigma'], rho=0.8)
+
+    # norm
+    x = np.random.normal(0., 1., (2 * par['nx'], par['nx'])).astype(par['dtype'])
+    rho = 0.8
+    l21_plus_l1_ = par['sigma'] * rho * np.sum(np.abs(x)) + par['sigma'] * (1 - rho) * np.sum(
+        np.sqrt(np.sum(x ** 2, axis=0))
+    )
+    assert_array_almost_equal(l21_plus_l1(x), l21_plus_l1_)
+
+    tau = 2.
+    l21_plus_l1.prox(x, tau)
+
+    assert moreau(l21_plus_l1, x, tau)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2)])

--- a/pytests/test_norms.py
+++ b/pytests/test_norms.py
@@ -138,7 +138,7 @@ def test_L21(par):
 def test_L21_plus_L1(par):
     """L21 plus L1 norm on 2darray.
     """
-    l21_plus_l1 = L21_plus_L1(ndim=2, sigma=par['sigma'], rho=0.8)
+    l21_plus_l1 = L21_plus_L1(sigma=par['sigma'], rho=0.8)
 
     # norm
     x = np.random.normal(0., 1., (2 * par['nx'], par['nx'])).astype(par['dtype'])


### PR DESCRIPTION
Closes none.

This PR stems off a conversation in [issue #241 in pylops](https://github.com/PyLops/pylops/issues/264). It adds the proximal operator for an L21 + L1 mixed-norm.