### PR TITLE
Allow tau to be vector

### DIFF
--- a/pyproximal/ProxOperator.py
+++ b/pyproximal/ProxOperator.py
@@ -9,7 +9,7 @@ def _check_tau(func):
 
     """
     def wrapper(*args, **kwargs):
-        if args[2] <= 0:
+        if np.any(args[2] <= 0):
             raise ValueError('tau must be positive')
         return func(*args, **kwargs)
     return wrapper


### PR DESCRIPTION
Based on https://github.com/PyLops/pyproximal/issues/41, we allow now tau to be also a vector in the case of solving problems with multiple RHS.