### PR TITLE
Fix proximal operator for log penalty

### DIFF
--- a/pyproximal/proximal/Log.py
+++ b/pyproximal/proximal/Log.py
@@ -53,18 +53,14 @@ class Log(ProxOperator):
     def prox(self, x, tau):
         k = tau * self.sigma / np.log(self.gamma + 1)
         out = np.zeros_like(x)
-        f = lambda x, y: k * np.log(self.sigma * np.abs(x) + 1) + (x - np.abs(y)) ** 2 / 2
         for i, y in enumerate(x):
-            b = self.sigma * np.abs(y) - 1
-            discriminant = b ** 2 - 4 * self.sigma * (k * self.sigma - np.abs(y))
-            if discriminant < 0:
-                out[i] = 0
-            else:
+            b = self.gamma * np.abs(y) - 1
+            discriminant = b ** 2 - 4 * self.gamma * (k * self.gamma - np.abs(y))
+            if discriminant >= 0:
                 c = np.sqrt(discriminant)
-                r1 = (b + c) / (2 * self.sigma)
-                r2 = (b - c) / (2 * self.sigma)
-                f1 = f(r1, y)
-                f2 = f(r2, y)
-                out[i] = r1 if f1 < f2 else r2
+                r = np.array([0, (b - c) / (2 * self.gamma), (b + c) / (2 * self.gamma)])
+                val = tau * self.elementwise(r) + (r - np.abs(y)) ** 2 / 2
+                idx = np.argmin(val)
+                out[i] = r[idx]
                 out[i] *= np.sign(y)
         return out


### PR DESCRIPTION
There was a bug in the proximal operator of the log penalty. I based the implementation on a piece of Matlab code that I found in the code repo of a peer-reviewed journal article, so I assumed that it was correct, but, unfortunately it missed a case (it assumed that the minima was obtained in a stationary point, but since it is non-convex it can also be at the endpoints of the interval).

I became suspicious when I implemented the ETP penalty from scratch, so I double checked the Log implementation and found it. I will be extra careful with the other once.