### PR TITLE
Implement Geman penalty

### DIFF
--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -78,6 +78,7 @@ Operators
     SCAD
     Log
     ETP
+    Geman
 
 
 Other operators

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -136,9 +136,9 @@ html_context = {
 mathjax3_config = {
     "tex": {
         "macros": {
-            "prox": r"\mathrm{prox}",
-            "sgn": r"\mathrm{sgn}",
-            "argmin": r"\mathrm{argmin}",
+            "prox": r"\operatorname{prox}",
+            "sgn": r"\operatorname{sgn}",
+            "argmin": r"\operatorname*{argmin}",
         }
     }
 }

--- a/examples/plot_concave_penalties.py
+++ b/examples/plot_concave_penalties.py
@@ -49,3 +49,9 @@ compare_penalty_and_proximal_operator(log)
 # l1-penalty and the l0-penalty at its extremes.
 etp = pyproximal.ETP(1, 0.25)
 compare_penalty_and_proximal_operator(etp)
+
+
+###############################################################################
+# The Geman penalty
+geman = pyproximal.Geman(3, 1.2)
+compare_penalty_and_proximal_operator(geman)

--- a/pyproximal/proximal/Geman.py
+++ b/pyproximal/proximal/Geman.py
@@ -1,0 +1,84 @@
+import numpy as np
+
+from pyproximal.ProxOperator import _check_tau
+from pyproximal import ProxOperator
+
+
+class Geman(ProxOperator):
+    r"""Geman penalty.
+
+    The Geman penalty (named after its inventor) is a non-convex penalty [1]_.
+    The pyproximal implementation considers a generalized model where
+
+    .. math::
+
+        \mathrm{Geman}_{\sigma,\gamma}(\mathbf{x}) = \sum_i \frac{\sigma |x_i|}{|x_i| + \gamma}
+
+    where :math:`{\sigma\geq 0}`, :math:`{\gamma>0}`.
+
+    Parameters
+    ----------
+    sigma : :obj:`float`
+        Regularization parameter.
+    gamma : :obj:`float`, optional
+        Regularization parameter. Default is 1.3.
+
+    Notes
+    -----
+    In order to compute the proximal operator of the Geman penalty one must find the
+    roots of a cubic polynomial. Consider the one-dimensional problem
+
+    .. math::
+        \prox_{\tau \mathrm{Geman}(\cdot)}(x) = \argmin_{z} \mathrm{Geman}(z) + \frac{1}{2\tau}(x - z)^2
+
+    and assume :math:`{x\geq 0}`. Either the minimum is obtained when :math:`z=0` or
+    when
+
+    .. math::
+        \tau\sigma\gamma + (z-x)(z+\gamma)^2 = 0 .
+
+    The pyproximal implementation uses the closed-form solution for a cubic equation,
+    and discards infeasible roots, to find the minimum.
+
+    .. [1] Geman and Yang "Nonlinear image recovery with half-quadratic regularization",
+        IEEE Transactions on Image Processing, 4(7):932 – 946, 1995.
+
+    """
+
+    def __init__(self, sigma, gamma=1.3):
+        super().__init__(None, False)
+        if sigma < 0:
+            raise ValueError('Variable "sigma" must be positive.')
+        if gamma <= 0:
+            raise ValueError('Variable "gamma" must be strictly positive.')
+        self.sigma = sigma
+        self.gamma = gamma
+
+    def __call__(self, x):
+        return np.sum(self.elementwise(x))
+
+    def elementwise(self, x):
+        return self.sigma * np.abs(x) / (np.abs(x) + self.gamma)
+
+    @_check_tau
+    def prox(self, x, tau):
+        out = np.zeros_like(x)
+        b = 2 * self.gamma - np.abs(x)
+        c = self.gamma ** 2 - 2 * self.gamma * np.abs(x)
+        d = self.gamma * self.sigma * tau - self.gamma ** 2 * np.abs(x)
+        idx, loc_mins = self._find_local_minima(b, c, d)
+        global_min_idx = tau * self.elementwise(loc_mins) + \
+            (loc_mins - np.abs(x[idx])) ** 2 / 2 < np.abs(x[idx]) ** 2 / 2
+        idx[idx] = global_min_idx
+        out[idx] = np.sign(x[idx]) * loc_mins[global_min_idx]
+        return out
+
+    @staticmethod
+    def _find_local_minima(b, c, d):
+        f = -(c - b ** 2.0 / 3.0) ** 3.0 / 27.0
+        g = (2.0 * b ** 3.0 - 9.0 * b * c + 27.0 * d) / 27.0
+        idx = g ** 2.0 / 4.0 - f <= 0
+        sqrtf = np.sqrt(f[idx])
+        k = np.arccos(-(g[idx] / (2 * sqrtf)))
+        loc_mins = 2 * sqrtf ** (1 / 3.0) * np.cos(k / 3.0) - b[idx] / 3.0
+        return idx, loc_mins

--- a/pyproximal/proximal/__init__.py
+++ b/pyproximal/proximal/__init__.py
@@ -27,6 +27,7 @@ The subpackage proximal contains a number of proximal operators:
     SCAD                            Smoothly clipped absolute deviation
     Log                             Logarithmic
     ETP                             Exponential-type penalty
+    Geman                           Geman penalty
 
 """
 
@@ -49,9 +50,10 @@ from .VStack import *
 from .SCAD import *
 from .Log import *
 from .ETP import *
+from .Geman import *
 
 __all__ = ['Box', 'Simplex', 'Intersection', 'AffineSet', 'Quadratic',
            'Euclidean', 'EuclideanBall', 'L0Ball', 'L1', 'L1Ball', 'L2',
            'L2Convolve', 'L21', 'L21_plus_L1', 'Huber', 'Nuclear',
            'NuclearBall', 'Orthogonal', 'VStack', 'Nonlinear', 'SCAD',
-           'Log', 'ETP']
+           'Log', 'ETP', 'Geman']

--- a/pytests/test_concave_penalties.py
+++ b/pytests/test_concave_penalties.py
@@ -3,7 +3,7 @@ import pytest
 import numpy as np
 
 from pyproximal.utils import moreau
-from pyproximal.proximal import ETP, Log, SCAD
+from pyproximal.proximal import ETP, Geman, Log, SCAD
 
 par1 = {'nx': 10, 'sigma': 1., 'a': 2.1, 'gamma': 0.5, 'dtype': 'float32'}  # even float32
 par2 = {'nx': 11, 'sigma': 2., 'a': 3.7, 'gamma': 5.0, 'dtype': 'float64'}  # odd float64
@@ -63,3 +63,19 @@ def test_ETP(par):
     # Check proximal operator
     tau = 2.
     assert moreau(etp, x, tau)
+
+
+@pytest.mark.parametrize("par", [(par1), (par2)])
+def test_Geman(par):
+    """Geman penalty and proximal/dual proximal
+    """
+    np.random.seed(10)
+    geman = Geman(sigma=par['sigma'], gamma=par['gamma'])
+    # Geman
+    x = np.random.normal(0., 10.0, par['nx']).astype(par['dtype'])
+    expected = par['sigma'] * np.linalg.norm(np.abs(x) / (np.abs(x) + par['gamma']), 1)
+    assert geman(x) == pytest.approx(expected)
+
+    # Check proximal operator
+    tau = 2.
+    assert moreau(geman, x, tau)


### PR DESCRIPTION
This implements the Geman penalty (named after its inventor). The name "Geman" has been used in multiple papers, so I think it is fine, since it was not given a name in the original paper.

This depends on the ETP penalty #64, and should be rebased after it is merged to main.