### PR TITLE
Update documentation of non-convex penalties with proper styling

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -132,6 +132,16 @@ html_context = {
     'github_version': 'master',
 }
 
+# Math macros
+mathjax3_config = {
+    "tex": {
+        "macros": {
+            "prox": r"\mathrm{prox}",
+            "sgn": r"\mathrm{sgn}",
+            "argmin": r"\mathrm{argmin}",
+        }
+    }
+}
 
 # Load the custom CSS files (needs sphinx >= 1.6 for this to work)
 def setup(app):

--- a/pyproximal/proximal/ETP.py
+++ b/pyproximal/proximal/ETP.py
@@ -12,9 +12,9 @@ class ETP(ProxOperator):
 
     .. math::
 
-        ETP_{\sigma,\gamma}(\mathbf{x}) = \sum_i \frac{\sigma}{1-e^{-\gamma}}(1-e^{-\gamma|x_i|})
+        \mathrm{ETP}_{\sigma,\gamma}(\mathbf{x}) = \sum_i \frac{\sigma}{1-e^{-\gamma}}(1-e^{-\gamma|x_i|})
 
-    for :math:`{\sigma>0}`, and :math:`{\gamma\geq 0}`.
+    for :math:`{\sigma>0}`, and :math:`{\gamma>0}`.
 
     Parameters
     ----------
@@ -25,14 +25,14 @@ class ETP(ProxOperator):
 
     Notes
     -----
-    As :math:`{\gamma\rightarrow 0}` the exponential-type penalty approaches the l1-penalty and when
-    :math:`{\gamma\rightarrow\infty}` tends to the l0-penalty [1]_.
+    As :math:`{\gamma\rightarrow 0}` the exponential-type penalty approaches the :math:`\ell_1`-penalty and when
+    :math:`{\gamma\rightarrow\infty}` tends to the :math:`\ell_0`-penalty [1]_.
 
-    As for the proximal operator, consider the 1-dimensional case
+    As for the proximal operator, consider the one-dimensional case
 
     .. math::
 
-        prox_{\tau ETP(\cdot)}(x) = argmin_{z} ETP(z) + \frac{1}{2\tau}\|x - z\|_2^2
+        \prox_{\tau \mathrm{ETP}(\cdot)}(x) = \argmin_{z} \mathrm{ETP}(z) + \frac{1}{2\tau}(x - z)^2
 
     and assume that :math:`x\geq 0`. The minima can be obtained when :math:`z=0` or at a stationary point,
     where the latter must satisfy

--- a/pyproximal/proximal/Log.py
+++ b/pyproximal/proximal/Log.py
@@ -11,7 +11,7 @@ class Log(ProxOperator):
 
     .. math::
 
-        Log_{\sigma,\gamma}(\mathbf{x}) = \sum_i \frac{\sigma}{\log(\gamma + 1)}\log(\gamma|x_i| + 1)
+        \mathrm{Log}_{\sigma,\gamma}(\mathbf{x}) = \sum_i \frac{\sigma}{\log(\gamma + 1)}\log(\gamma|x_i| + 1)
 
     where :math:`{\sigma>0}`, :math:`{\gamma>0}`.
 
@@ -24,26 +24,28 @@ class Log(ProxOperator):
 
     Notes
     -----
-    The logarithmic penalty is an extension of the elastic net family of penalties to non-convex members, which
-    should produce sparser solutions compared to the l1-penalty [1]_. The pyproximal implementation considers a scaled
-    version that satisfies :math:`{Log_{\sigma,\gamma}(0) = 0}` and
-    :math:`{Log_{\sigma,\gamma}(1) = \sigma}`, which is suitable also for penalizing singular values. Note that when
-    :math:`{\gamma\rightarrow 0}` the logarithmic penalty approaches the l1-penalty and when
-    :math:`{\gamma\rightarrow\infty}` it mimicks the l0-penalty.
+    The logarithmic penalty is an extension of the elastic net family of penalties to
+    non-convex members, which should produce sparser solutions compared to the
+    :math:`\ell_1`-penalty [1]_. The pyproximal implementation considers a scaled
+    version that satisfies :math:`{\mathrm{Log}_{\sigma,\gamma}(0) = 0}` and
+    :math:`{\mathrm{Log}_{\sigma,\gamma}(1) = \sigma}`, which is suitable also for
+    penalizing singular values. Note that when :math:`{\gamma\rightarrow 0}` the
+    logarithmic penalty approaches the l1-penalty and when
+    :math:`{\gamma\rightarrow\infty}` it mimicks the :math:`\ell_0`-penalty.
 
-    The proximal operator can be analyzed using the 1-dimensional case
+    The proximal operator can be analyzed using the one-dimensional case
 
     .. math::
-        prox_{\tau Log(\cdot)}(x) = argmin_{z} Log(z) + \frac{1}{2\tau}(x - z)^2
+        \prox_{\tau \mathrm{Log}(\cdot)}(x) = \argmin_{z} \mathrm{Log}(z) + \frac{1}{2\tau}(x - z)^2
 
-    where we assume that :math:`x\geq 0`. The minima can be obtained when :math:`z=0` or at a local minimum.
-    Consider therefore
+    where we assume that :math:`x\geq 0`. The minima can be obtained when :math:`z=0`
+    or at a local minimum. Consider therefore
 
     .. math::
         f(z) = k \log(\gamma x + 1) + \frac{1}{2} (x - z)^2
 
-    where :math:`k= \frac{\tau \sigma}{\log(\gamma + 1)}` is introduced for convenience.
-    The condition that :math:`f'(z) = 0` yields the following equation
+    where :math:`k= \frac{\tau \sigma}{\log(\gamma + 1)}` is introduced for
+    convenience. The condition that :math:`f'(z) = 0` yields the following equation
 
     .. math::
         \gamma z^2 + (1-\gamma y) x + k\gamma - y = 0 .

--- a/pyproximal/proximal/Log.py
+++ b/pyproximal/proximal/Log.py
@@ -94,7 +94,6 @@ class Log(ProxOperator):
         r = np.vstack((np.zeros_like(c), (b[idx] + c) / (2 * self.gamma)))
         val = tau * self.elementwise(r) + (r - np.abs(x[idx])) ** 2 / 2
         idx_minima = np.argmin(val, axis=0)
-        print(np.unique(idx_minima))
         out[idx] = r[idx_minima, range(r.shape[1])]
         out *= np.sign(x)
         return out

--- a/pyproximal/proximal/SCAD.py
+++ b/pyproximal/proximal/SCAD.py
@@ -7,28 +7,42 @@ from pyproximal import ProxOperator
 class SCAD(ProxOperator):
     r"""Smoothly clipped absolute deviation (SCAD) penalty.
 
-    Parameters
-    ----------
-    sigma : :obj:`float`
-        First threshold parameter (named :math:`\lambda` in the original paper [1])
-    a : :obj:`float`, optional
-        Second threshold parameter (must be larger than 2). Default is 3.7, see [1] for more information.
-
-    Notes
-    -----
     The SCAD penalty is a concave function and is defined as
 
     .. math::
 
-        SCAD_{\sigma}(\mathbf{x}) =
+        \mathrm{SCAD}_{\sigma, a}(\mathbf{x}) =
         \begin{cases}
         \sigma x_i, & |x_i| \leq \sigma \\
         \frac{-x_i^2 + 2 a \sigma  - \sigma^2}{2 (a - 1)}, & \sigma < |x_i| \leq a\sigma \\
         \frac{(a + 1)\sigma^2}{2}, & |x_i| > a\sigma
         \end{cases}
 
-    Furthermore, it is continuous and differentiable and does not suffer from biasedness as the l1-norm, nor is
-    discontinuous as the hard thresholding penalty. Thus, it fuses the most favourable properties of both penalties.
+    Parameters
+    ----------
+    sigma : :obj:`float`
+        First threshold parameter (named :math:`\lambda` in the original paper [1]_)
+    a : :obj:`float`, optional
+        Second threshold parameter (must be larger than 2). Default is 3.7, see [1]_ for more information.
+
+    Notes
+    -----
+
+    The SCAD penalty is continuous and differentiable and does not suffer from
+    biasedness as the :math:`\ell_1`-norm, nor is discontinuous as the hard
+    thresholding penalty. Thus, it fuses the most favourable properties of both
+    penalties.
+
+    The proximal operator is given by
+
+    .. math::
+
+        \prox_{\tau \mathrm{SCAD}_{\sigma, a}(\cdot)}(\mathbf{x}) =
+        \begin{cases}
+        \sgn(x_i)\max(0, |x_i| - \sigma), & |x_i| \leq \frac{\sigma(a - 1 - \tau + a\tau)}{a - 1} \\
+        \frac{(a-1)x_i - \sgn(x_i)a\tau\sigma}{a-1-\tau}, & \frac{\sigma(a - 1 - \tau + a\tau)}{a - 1} < |x_i| \leq a\sigma \\
+        x_i, & |x_i| > a\sigma
+        \end{cases}
 
     .. [1] Fan, J. and Li, R. "Variable selection via nonconcave penalized likelihood and its oracle
         properties" Journal of the American Statistical Association, 96(456):1348–1360, 2001


### PR DESCRIPTION
In the beginning I was not aware of the correct way of writing the docstrings, so I went through the existing ones and made them nicer and more coherent. I also removed a debug print.