### PR TITLE
Fixed error in nonlinearconstrained tutorial

### DIFF
--- a/tutorials/nonlinearconstrained.py
+++ b/tutorials/nonlinearconstrained.py
@@ -171,10 +171,11 @@ class Rosebrock_lbfgs(Rosebrock):
 
         self.solhist = []
         self.solhist.append(self.x0)
-        sol = sp.optimize.minimize(self.fun, x0=self.x0,
-                                      jac=lambda x: self._gradprox(x, self.tau),
-                                      method='L-BFGS-B', callback=callback,
-                                      options=dict(maxiter=15))
+        sol = sp.optimize.minimize(lambda x: self._funprox(x, self.tau),
+                                   x0=self.x0,
+                                   jac=lambda x: self._gradprox(x, self.tau),
+                                   method='L-BFGS-B', callback=callback,
+                                   options=dict(maxiter=15))
         sol = sol.x
 
         self.solhist = np.array(self.solhist)


### PR DESCRIPTION
In the `nonlinearconstrained` tutorial, when computing the proximal of a nonlinear functional, the function evaluation passed to `scipy.optimize` should have not been the function itself but the expression of the proximal - this is what we want to minimise 