### PR TITLE
Modified L2 for cupy

### DIFF
--- a/pyproximal/projection/AffineSet.py
+++ b/pyproximal/projection/AffineSet.py
@@ -1,7 +1,7 @@
 from scipy.sparse.linalg import lsqr as sp_lsqr
-
 from pylops.optimization.basic import lsqr
 from pylops.utils.backend import get_array_module, get_module_name
+
 
 class AffineSetProj():
     r"""Affine set projection.


### PR DESCRIPTION
This PR modifies the L2 proximal operator such that it can interchangeably work with both NumPy and CuPy arrays.