### PR TITLE
fix: use cg instead of lsqr in AffineSet

### DIFF
--- a/pyproximal/projection/AffineSet.py
+++ b/pyproximal/projection/AffineSet.py
@@ -1,5 +1,6 @@
 from scipy.sparse.linalg import lsqr as sp_lsqr
-from pylops.optimization.basic import lsqr
+from scipy.sparse.linalg import cg as sp_cg
+from pylops.optimization.basic import cg, lsqr
 from pylops.utils.backend import get_array_module, get_module_name
 
 
@@ -41,8 +42,8 @@ class AffineSetProj():
 
     def __call__(self, x):
         if get_module_name(get_array_module(x)) == 'numpy':
-            inv = sp_lsqr(self.Op * self.Op.H, self.Op * x - self.b, iter_lim=self.niter)[0]
+            inv = sp_cg(self.Op * self.Op.H, self.Op * x - self.b, maxiter=self.niter)[0]
         else:
-            inv = lsqr(self.Op * self.Op.H, self.Op * x - self.b, niter=self.niter)[0]
+            inv = cg(self.Op * self.Op.H, self.Op * x - self.b, niter=self.niter)[0]
         y = x - self.Op.H * inv.ravel() # currently ravel is added to ensure that the output is always a vector
         return y

--- a/pyproximal/projection/Hankel.py
+++ b/pyproximal/projection/Hankel.py
@@ -2,7 +2,7 @@ import numpy as np
 from scipy.linalg import hankel
 
 
-class HankelProj:
+class HankelProj():
     r"""Hankel matrix projection.
 
     Solves the least squares problem

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ pytest
 pytest-runner
 setuptools_scm
 docutils<0.18
-Sphinx==4.2.0
+Sphinx
 sphinx-gallery
 pydata-sphinx-theme
 numpydoc


### PR DESCRIPTION
Given that we are solving a problem with a square matrix, `cg` is a more suitable choice