### PR TITLE
feat: added fungrad to Nonlinear

### DIFF
--- a/pyproximal/proximal/Nonlinear.py
+++ b/pyproximal/proximal/Nonlinear.py
@@ -14,6 +14,8 @@ class Nonlinear(ProxOperator):
     - ``fun``: a method evaluating the generic function :math:`f`
     - ``grad``: a method evaluating the gradient of the generic function
       :math:`f`
+    - ``fungrad``: a method evaluating both the generic function :math:`f` 
+      and its gradient
     - ``optimize``: a method that solves the optimization problem associated
       with the proximal operator of :math:`f`. Note that the
       ``gradprox`` method must be used (instead of ``grad``) as this will
@@ -58,11 +60,21 @@ class Nonlinear(ProxOperator):
     def _gradprox(self, x, tau):
         return self.grad(x) + 1. / tau * (x - self.y)
 
+    def _fungradprox(self, x, tau):
+        f, g = self.fungrad(x)
+        f = f + 1. / (2 * tau) * ((x - self.y) ** 2).sum()
+        g = g + 1. / tau * (x - self.y)
+        return f, g
+
     def fun(self, x):
         raise NotImplementedError('The method fun has not been implemented.'
                                   'Refer to the documentation for details on '
                                   'how to subclass this operator.')
     def grad(self, x):
+        raise NotImplementedError('The method grad has not been implemented.'
+                                  'Refer to the documentation for details on '
+                                  'how to subclass this operator.')
+    def fungrad(self, x):
         raise NotImplementedError('The method grad has not been implemented.'
                                   'Refer to the documentation for details on '
                                   'how to subclass this operator.')

--- a/pytests/test_grads.py
+++ b/pytests/test_grads.py
@@ -52,6 +52,7 @@ def test_l2(par):
                           raiseerror=True, atol=1e-3,
                           verb=False)
 
+
 @pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])
 def test_lowrank(par):
     """LowRankFactorizedMatrix gradient


### PR DESCRIPTION
This PR introduces `fungrad` in `Nonlinear` to enable cases where it is more efficient to compute the function and gradient of a nonlinear operator in one go by sharing some of the operations.