### PR TITLE
feat: added grad of Moreau envelope to grad method of ProxOperator

### DIFF
--- a/pyproximal/ProxOperator.py
+++ b/pyproximal/ProxOperator.py
@@ -25,10 +25,17 @@ class ProxOperator(object):
     subclasses the ``ProxOperator`` class needs at least one of these two
     methods to be implemented directly.
 
-    .. note:: End users of PyProx should not use this class directly but simply
+    Moreover, the method ``grad`` is also defined to compute the gradient of
+    the Moreau envelope of the function. This function is only called if the
+    user does not provide a gradient function when creating the proximal operator.
+    The variable ``hasgrad`` is used to indicate if the function has a gradient
+    or not (and thus if the ``grad`` method computes the gradient of the actual
+    function or of its Moreau envelope).
+
+    .. note:: End users of PyProximal should not use this class directly but simply
       use operators that are already implemented. This class is meant for
       developers and it has to be used as the parent class of any new operator
-      developed within PyProx. Find more details regarding implementation of
+      developed within PyProximal. Find more details regarding implementation of
       new operators at :ref:`addingoperator`.
 
     Parameters
@@ -38,6 +45,10 @@ class ProxOperator(object):
     hasgrad : :obj:`bool`, optional
         Flag to indicate if the function is differentiable, i.e., has a
         uniquely defined gradient (``True``) or not (``False``).
+    sigmame : :obj:`float`, optional
+        Relaxation parameter of the Moreau envelope (when ``sigmame`` tends to infinity
+        the gradient of the Moreau envelope tends to the gradient of the function itself).
+        Refer to the docstring of the ``grad`` method for more details.
 
     Notes
     -----
@@ -49,9 +60,10 @@ class ProxOperator(object):
         \frac{1}{2 \tau}||\mathbf{y} - \mathbf{x}||^2_2
 
     """
-    def __init__(self, Op=None, hasgrad=False):
+    def __init__(self, Op=None, hasgrad=False, sigmame=1.):
         self.Op = Op
         self.hasgrad = hasgrad
+        self.sigmame = sigmame
 
     @_check_tau
     def _prox_moreau(self, x, tau, **kwargs):
@@ -120,21 +132,31 @@ class ProxOperator(object):
         return self._proxdual_moreau(x, tau, **kwargs)
 
     def grad(self, x):
-        """Compute gradient
+        """Compute gradient of the Moreau envelope of the function.
+
+        This method is only called if the user does not provide a gradient
+        because the function is not differentiable. In this case, the gradient
+        of the Moreau envelope of the function is computed instead:
+
+        .. math::
+
+            \nabla_\mathbf{x} M_{\sigma f) = 
+            \frac{1}{sigma} (\mathbf{x} - \prox_{\sigma f}(\mathbf{x}))
 
         Parameters
         ----------
         x : :obj:`np.ndarray`
             Vector
-
+        
         Returns
         -------
         g : :obj:`np.ndarray`
             Gradient vector
 
         """
-        pass
-
+        g = (x - self.prox(x, self.sigmame)) / self.sigmame
+        return g
+    
     def affine_addition(self, v):
         """Affine addition
 

--- a/pyproximal/__init__.py
+++ b/pyproximal/__init__.py
@@ -1,9 +1,29 @@
 """
-PyProx
-======
+PyProximal
+==========
 
-....
+This Python library provides all the needed building blocks for solving
+non-smooth convex optimization problems using the so-called proximal algorithms.
+
+PyProximal provides
+  1. A general construct for creating proximal operators
+  2. An extensive set of commonly used proximal operators
+  3. A set of solvers for composite objective functions with 
+     differentiable and proximable functions.
+
+Available subpackages
+---------------------
+projection
+    Project Operators
+proximal
+    Proximal Operators
+optimization
+    Solvers
+utils
+    Utility routines
+
 """
+
 from .ProxOperator import ProxOperator
 from .proximal import *
 

--- a/pyproximal/proximal/L1.py
+++ b/pyproximal/proximal/L1.py
@@ -86,7 +86,7 @@ class L1(ProxOperator):
         \sigma,  & x_i > \sigma\\
         \end{cases}
 
-    .. [1] Chambolle, and A., Pock, "A first-order primal-dual algorithm for
+    .. [1] Chambolle, and A., Pock, "A first-order primal-dual algorithm for
         convex problems with applications to imaging", Journal of Mathematical
         Imaging and Vision, 40, 8pp. 120–145. 2011.
 

--- a/pytests/test_bilinear.py
+++ b/pytests/test_bilinear.py
@@ -27,8 +27,8 @@ def test_lrfactorized(par):
     X = U @ V.T
     LOp = LowRankFactorizedMatrix(U, V.T, X)
 
-    assert_array_almost_equal(X.ravel(), LOp._matvecx(U.ravel()), decimal=6)
-    assert_array_almost_equal(X.ravel(), LOp._matvecy(V.T.ravel()), decimal=6)
+    assert_array_almost_equal(X.ravel(), LOp._matvecx(U.ravel()), decimal=4)
+    assert_array_almost_equal(X.ravel(), LOp._matvecy(V.T.ravel()), decimal=4)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2)])
@@ -46,5 +46,5 @@ def test_lrfactorizedoperator(par):
 
     LOp = LowRankFactorizedMatrix(U, V.T, y, Op)
 
-    assert_array_almost_equal(y, LOp._matvecx(U.ravel()), decimal=6)
-    assert_array_almost_equal(y, LOp._matvecy(V.T.ravel()), decimal=6)
+    assert_array_almost_equal(y, LOp._matvecx(U.ravel()), decimal=4)
+    assert_array_almost_equal(y, LOp._matvecy(V.T.ravel()), decimal=4)

--- a/pytests/test_bilinear.py
+++ b/pytests/test_bilinear.py
@@ -1,7 +1,7 @@
 import pytest
 
 import numpy as np
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_almost_equal
 from pylops import Diagonal
 
 from pyproximal.utils.bilinear import LowRankFactorizedMatrix
@@ -27,8 +27,8 @@ def test_lrfactorized(par):
     X = U @ V.T
     LOp = LowRankFactorizedMatrix(U, V.T, X)
 
-    assert_array_equal(X.ravel(), LOp._matvecx(U.ravel()))
-    assert_array_equal(X.ravel(), LOp._matvecy(V.T.ravel()))
+    assert_array_almost_equal(X.ravel(), LOp._matvecx(U.ravel()), decimal=6)
+    assert_array_almost_equal(X.ravel(), LOp._matvecy(V.T.ravel()), decimal=6)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2)])
@@ -46,5 +46,5 @@ def test_lrfactorizedoperator(par):
 
     LOp = LowRankFactorizedMatrix(U, V.T, y, Op)
 
-    assert_array_equal(y, LOp._matvecx(U.ravel()))
-    assert_array_equal(y, LOp._matvecy(V.T.ravel()))
+    assert_array_almost_equal(y, LOp._matvecx(U.ravel()), decimal=6)
+    assert_array_almost_equal(y, LOp._matvecy(V.T.ravel()), decimal=6)


### PR DESCRIPTION
This PR implements the gradient of Moreau envelope in the `grad` method of `ProxOperator`. 

This will be called every time the method `grad` of a given proximal operator and the proximal operator does not implement the `grad` method itself (when, for example, the gradient of the function does not exist)