### PR TITLE
fix: changed L01Ball into L10Ball

### DIFF
--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -24,7 +24,7 @@ Orthogonal projections
     HyperPlaneBoxProj
     IntersectionProj
     L0BallProj
-    L01BallProj
+    L10BallProj
     L1BallProj
     NuclearBallProj
     SimplexProj
@@ -70,7 +70,7 @@ Convex
     Intersection
     L0
     L0Ball
-    L01Ball
+    L10Ball
     L1
     L1Ball
     L2

--- a/pyproximal/projection/L0.py
+++ b/pyproximal/projection/L0.py
@@ -1,3 +1,4 @@
+import warnings
 import numpy as np
 
 
@@ -34,8 +35,8 @@ class L0BallProj():
         return xf.reshape(xshape)
 
 
-class L01BallProj():
-    r""":math:`L_{0,1}` ball projection.
+class L10BallProj():
+    r""":math:`L_{1,0}` ball projection.
 
     Parameters
     ----------
@@ -44,11 +45,11 @@ class L01BallProj():
 
     Notes
     -----
-    Given an :math:`L_{0,1}` ball defined as:
+    Given an :math:`L_{1,0}` ball defined as:
 
     .. math::
 
-        L_{0,1}^{r} =
+        L_{1,0}^{r} =
         \{ \mathbf{x}: \text{count}([||\mathbf{x}_1||_1,
         ||\mathbf{x}_2||_1, ..., ||\mathbf{x}_1||_1] \ne 0) \leq r \}
 
@@ -57,7 +58,7 @@ class L01BallProj():
     column of a matrix :math:`\mathbf{x}` (in absolute value), keeping those
     and zero-ing all the other entries.
     Note that this is the proximal operator of the corresponding
-    indicator function :math:`\mathcal{I}_{L_{0,1}^{r}}`.
+    indicator function :math:`\mathcal{I}_{L_{1,0}^{r}}`.
 
     """
     def __init__(self, radius):
@@ -68,3 +69,14 @@ class L01BallProj():
         xf = np.linalg.norm(x, axis=0, ord=1)
         xc[:, np.argsort(np.abs(xf))[:-self.radius]] = 0
         return xc
+
+
+class L01BallProj(L10BallProj):
+    def __init__(self, radius):
+        warnings.warn(
+            "The L01BallProj class has been renamed L10BallProj due " \
+            "to a mistake in the original choice of the name. As such " \
+            "L01BallProj will be deprecated in v1.0.0.",
+            FutureWarning,
+        )
+        self.super().__init__(radius)

--- a/pyproximal/projection/__init__.py
+++ b/pyproximal/projection/__init__.py
@@ -8,7 +8,8 @@ The subpackage projection contains a number of orthogonal projection:
     HyperPlaneBoxProj	        Projection onto an intersection beween a HyperPlane and a Box
     SimplexProj	                Projection onto a Simplex
     L0Proj	                    Projection onto an L0 Ball
-    L01Proj	                    Projection onto an L0,1 Ball
+    L01Proj	                    Projection onto an L1,0 Ball (deprecated)
+    L10Proj	                    Projection onto an L1,0 Ball
     L1Proj	                    Projection onto an L1 Ball
     EuclideanBallProj	        Projection onto an Euclidean Ball
     NuclearBallProj	            Projection onto a Nuclear Ball
@@ -30,5 +31,6 @@ from .Hankel import *
 
 
 __all__ = ['BoxProj', 'HyperPlaneBoxProj', 'SimplexProj', 'L0BallProj',
-           'L01BallProj', 'L1BallProj', 'EuclideanBallProj', 'NuclearBallProj',
-           'IntersectionProj', 'AffineSetProj', 'HankelProj']
+           'L01BallProj', 'L10BallProj', 'L1BallProj', 'EuclideanBallProj',
+           'NuclearBallProj', 'IntersectionProj', 'AffineSetProj',
+           'HankelProj']

--- a/pyproximal/proximal/L0.py
+++ b/pyproximal/proximal/L0.py
@@ -1,7 +1,8 @@
+import warnings
 import numpy as np
 
 from pyproximal.ProxOperator import _check_tau
-from pyproximal.projection import L0BallProj, L01BallProj
+from pyproximal.projection import L0BallProj, L10BallProj
 from pyproximal import ProxOperator
 from pyproximal.proximal.L1 import _current_sigma
 
@@ -138,10 +139,10 @@ class L0Ball(ProxOperator):
         return y
 
 
-class L01Ball(ProxOperator):
-    r""":math:`L_{0,1}` ball proximal operator.
+class L10Ball(ProxOperator):
+    r""":math:`L_{1,0}` ball proximal operator.
 
-    Proximal operator of the :math:`L_{0,1}` ball: :math:`L_{0,1}^{r} =
+    Proximal operator of the :math:`L_{1,0}` ball: :math:`L_{1,0}^{r} =
     \{ \mathbf{x}: \text{count}([||\mathbf{x}_1||_1, ||\mathbf{x}_2||_1, ...,
     ||\mathbf{x}_1||_1] \ne 0) \leq r \}`
 
@@ -162,14 +163,14 @@ class L01Ball(ProxOperator):
     -----
     As the L0 ball is an indicator function, the proximal operator
     corresponds to its orthogonal projection
-    (see :class:`pyproximal.projection.L01BallProj` for details.
+    (see :class:`pyproximal.projection.L10BallProj` for details.
 
     """
     def __init__(self, ndim, radius):
         super().__init__(None, False)
         self.ndim = ndim
         self.radius = radius
-        self.ball = L01BallProj(self.radius if not callable(radius) else radius(0))
+        self.ball = L10BallProj(self.radius if not callable(radius) else radius(0))
         self.count = 0
 
     def __call__(self, x, tol=1e-4):
@@ -193,3 +194,14 @@ class L01Ball(ProxOperator):
         self.ball.radius = radius
         y = self.ball(x)
         return y.ravel()
+
+
+class L01Ball(L10Ball):
+    def __init__(self, ndim, radius):
+        warnings.warn(
+            "The L01Ball class has been renamed L10Ball due " \
+            "to a mistake in the original choice of the name. As such " \
+            "L01Ball will be deprecated in v1.0.0.",
+            FutureWarning,
+        )
+        super().__init__(ndim, radius)

--- a/pyproximal/proximal/__init__.py
+++ b/pyproximal/proximal/__init__.py
@@ -12,7 +12,8 @@ The subpackage proximal contains a number of proximal operators:
     Nonlinear	                    Nonlinear function
     L0                              L0 Norm
     L0Ball                          L0 Ball
-    L01pBall                        L0,1 Ball
+    L01Ball                         L1,0 Ball (deprecated)
+    L10Ball                         L1,0 Ball (deprecated)
     L1	                            L1 Norm
     L1Ball                          L1 Ball
     Euclidean	                    Euclidean Norm
@@ -69,9 +70,10 @@ from .SingularValuePenalty import *
 from .Hankel import *
 
 __all__ = ['Box', 'Simplex', 'Intersection', 'AffineSet', 'Quadratic',
-           'Euclidean', 'EuclideanBall', 'L0', 'L0Ball', 'L01Ball', 'L1', 'L1Ball', 'L2',
-           'L2Convolve', 'L21', 'L21_plus_L1', 'Huber', 'HuberCircular', 'TV', 'RelaxedMumfordShah',
-           'Nuclear', 'NuclearBall', 'Orthogonal', 'VStack', 'Nonlinear', 'SCAD',
-           'Log', 'Log1', 'ETP', 'Geman', 'QuadraticEnvelopeCard', 'SingularValuePenalty',
+           'Euclidean', 'EuclideanBall', 'L0', 'L0Ball', 'L01Ball', 'L10Ball',
+           'L1', 'L1Ball', 'L2', 'L2Convolve', 'L21', 'L21_plus_L1', 'Huber',
+           'HuberCircular', 'TV', 'RelaxedMumfordShah', 'Nuclear', 'NuclearBall',
+           'Orthogonal', 'VStack', 'Nonlinear', 'SCAD', 'Log', 'Log1', 'ETP',
+           'Geman', 'QuadraticEnvelopeCard', 'SingularValuePenalty',
            'QuadraticEnvelopeCardIndicator', 'QuadraticEnvelopeRankL2',
            'Hankel']

--- a/pytests/test_projection.py
+++ b/pytests/test_projection.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.testing import assert_array_almost_equal
 from pylops.basicoperators import Identity
 from pyproximal.utils import moreau
-from pyproximal.proximal import Box, EuclideanBall, L0Ball, L01Ball, L1Ball, \
+from pyproximal.proximal import Box, EuclideanBall, L0Ball, L10Ball, L1Ball, \
     NuclearBall, Simplex, AffineSet, Hankel
 
 par1 = {'nx': 10, 'ny': 8, 'axis': 0, 'dtype': 'float32'}  # even float32 dir0
@@ -66,12 +66,12 @@ def test_L0Ball(par):
 
 
 @pytest.mark.parametrize("par", [(par1), (par2)])
-def test_L01Ball(par):
-    """L01 Ball projection and proximal/dual proximal of related indicator
+def test_L10Ball(par):
+    """L10 Ball projection and proximal/dual proximal of related indicator
     """
     np.random.seed(10)
 
-    l0 = L01Ball(3, 1)
+    l0 = L10Ball(3, 1)
     x = np.random.normal(0., 1., (3, par['nx'])).astype(par['dtype']).ravel() + 1.
 
     # evaluation

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -3,6 +3,7 @@ scipy>=1.11.0
 pylops>=2.0.0
 numba
 scikit-image
+pooch
 matplotlib
 ipython
 bm4d<4.2.4 # temporary as gclib problem arises in readthedocs

--- a/tutorials/basispursuit.py
+++ b/tutorials/basispursuit.py
@@ -18,7 +18,6 @@ on the data term which must be satisfied exactly. Similarly, we can also conside
 import numpy as np
 import matplotlib.pyplot as plt
 import pylops
-from scipy import misc
 
 import pyproximal
 

--- a/tutorials/denoising.py
+++ b/tutorials/denoising.py
@@ -23,7 +23,7 @@ For both examples we investigate with different choices of regularization:
 import numpy as np
 import matplotlib.pyplot as plt
 import pylops
-from scipy import misc
+from scipy import datasets
 
 import pyproximal
 
@@ -33,7 +33,7 @@ plt.close('all')
 # Let's start by loading a sample image and adding some noise
 
 # Load image
-img = misc.ascent()
+img = datasets.ascent()
 img = img / np.max(img)
 ny, nx = img.shape
 


### PR DESCRIPTION
This PR changes the naming of `L01Ball`/`L01BallProj` into `L10Ball`/`L10BallProj` due to a mistake in the initial definition; to avoid backward compatibility issues we also still keep `L01Ball`/`L01BallProj` by just subclassing `L10Ball`/`L10BallProj`) and add a deprecation warning.

Moreover small changes are made to the tutorials to remove reliance on `scipy.misc` which is deprecated in latest versions of Scipy.