### PR TITLE
bug: fix bug in L0 __call__ and add tests

### DIFF
--- a/pyproximal/proximal/L0.py
+++ b/pyproximal/proximal/L0.py
@@ -73,8 +73,7 @@ class L0(ProxOperator):
         self.count = 0
 
     def __call__(self, x):
-        sigma = _current_sigma(self.sigma, self.count)
-        return np.sum(np.abs(x) > sigma)
+        return np.sum(np.abs(x) > 0.)
 
     def _increment_count(func):
         """Increment counter

--- a/pytests/test_norms.py
+++ b/pytests/test_norms.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_array_almost_equal
 
 from pylops.basicoperators import Identity, Diagonal, MatrixMult, FirstDerivative
 from pyproximal.utils import moreau
-from pyproximal.proximal import Euclidean, L2, L1, L21, L21_plus_L1, \
+from pyproximal.proximal import Euclidean, L2, L1, L0, L21, L21_plus_L1, \
     Huber, HuberCircular, Nuclear, RelaxedMumfordShah, TV
 
 par1 = {'nx': 10, 'sigma': 1., 'dtype': 'float32'}  # even float32
@@ -136,6 +136,21 @@ def test_L1_diff(par):
     # prox / dualprox
     tau = 2.
     assert moreau(l1, x, tau)
+
+
+@pytest.mark.parametrize("par", [(par1), (par2)])
+def test_L0(par):
+    """L0 norm and proximal/dual proximal
+    """
+    l0 = L0(sigma=par['sigma'])
+
+    # norm
+    x = np.random.normal(0., 1., par['nx']).astype(par['dtype'])
+    assert l0(x) == np.sum(np.abs(x) >  0.)
+
+    # prox / dualprox
+    tau = 2.
+    assert moreau(l0, x, tau)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2)])


### PR DESCRIPTION
The current implementation of the L0 norm (`__call__` of L0) counts the values above sigma, however this should be 0. This is now fixed and tests for the L0 operator are added.