### PR TITLE
feat: Douglas-Rachford Splitting

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,3 +193,4 @@ When using PyProximal in scientific publications, please cite the following pape
 * Eneko Uruñuela, eurunuela
 * Marcus Valtonen Örnhag, marcusvaltonen
 * Olivier Leblanc, olivierleblanc
+* Toru Tamaki, tttamaki

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -167,6 +167,7 @@ Primal
     ProximalGradient
     ProximalPoint
     TwIST
+    DouglasRachfordSplitting
 
 .. currentmodule:: pyproximal.optimization.palm
 

--- a/docs/source/credits.rst
+++ b/docs/source/credits.rst
@@ -8,3 +8,4 @@ Contributors
 *  `Eneko Uruñuela <https://github.com/eurunuela>`_, eurunuela
 *  `Marcus Valtonen Örnhag <https://github.com/marcusvaltonen>`_, marcusvaltonen
 *  `Olivier Leblanc <https://github.com/olivierleblanc>`_, olivierleblanc
+*  `Toru Tamaki <https://github.com/tttamaki>`_, tttamaki

--- a/pyproximal/optimization/__init__.py
+++ b/pyproximal/optimization/__init__.py
@@ -19,6 +19,7 @@ operators:
     LinearizedADMM                  Linearized ADMM
     TwIST                           Two-step Iterative Shrinkage/Threshold
     PlugAndPlay                     Plug-and-Play Prior with ADMM
+    DouglasRachfordSplitting        Douglas-Rachford algorithm
 
 A list of solvers in ``pyproximal.optimization.proximaldual`` using both proximal
 and dual proximal operators:

--- a/pyproximal/optimization/primal.py
+++ b/pyproximal/optimization/primal.py
@@ -844,7 +844,7 @@ def ADMM(proxf, proxg, x0, tau, niter=10, gfirst=False,
     r"""Alternating Direction Method of Multipliers
 
     Solves the following minimization problem using Alternating Direction
-    Method of Multipliers (also known as Douglas-Rachford splitting):
+    Method of Multipliers:
 
     .. math::
 
@@ -910,7 +910,7 @@ def ADMM(proxf, proxg, x0, tau, niter=10, gfirst=False,
 
     Notes
     -----
-    The ADMM algorithm can be expressed by the following recursion:
+    The ADMM algorithm can be expressed by the following recursion [1]_:
 
     .. math::
 
@@ -922,6 +922,11 @@ def ADMM(proxf, proxg, x0, tau, niter=10, gfirst=False,
     stopped too early ``x`` is guaranteed to belong to the domain of ``f``
     while ``z`` is guaranteed to belong to the domain of ``g``. Depending on
     the problem either of the two may be the best solution.
+
+    .. [1] S. Boyd, N. Parikh, E. Chu, B. Peleato, and J. Eckstein. 2011.
+        Distributed optimization and statistical learning via the alternating
+        direction method of multipliers. Foundations and Trends in Machine
+        Learning, 3 (1), 1-122. https://doi.org/10.1561/2200000016.
 
     """
     if show:
@@ -1085,7 +1090,7 @@ def LinearizedADMM(proxf, proxg, A, x0, tau, mu, niter=10,
     r"""Linearized Alternating Direction Method of Multipliers
 
     Solves the following minimization problem using Linearized Alternating
-    Direction Method of Multipliers (also known as Douglas-Rachford splitting):
+    Direction Method of Multipliers:
 
     .. math::
 
@@ -1135,7 +1140,7 @@ def LinearizedADMM(proxf, proxg, A, x0, tau, mu, niter=10,
 
     Notes
     -----
-    The Linearized-ADMM algorithm can be expressed by the following recursion:
+    The Linearized-ADMM algorithm can be expressed by the following recursion [1]_:
 
     .. math::
 
@@ -1145,6 +1150,9 @@ def LinearizedADMM(proxf, proxg, A, x0, tau, mu, niter=10,
         \mathbf{u}^k)\\
         \mathbf{u}^{k+1} = \mathbf{u}^{k} + \mathbf{A}\mathbf{x}^{k+1} -
         \mathbf{z}^{k+1}
+
+    .. [1] N., Parikh, "Proximal Algorithms", Foundations and Trends
+        in Optimization. 2013.
 
     """
     if show:
@@ -1397,7 +1405,7 @@ def DouglasRachfordSplitting(
     Notes
     -----
     The Douglas-Rachford Splitting algorithm can be expressed by the following
-    recursion:
+    recursion [1]_, [2]_:
 
     .. math::
 

--- a/pyproximal/optimization/primal.py
+++ b/pyproximal/optimization/primal.py
@@ -1336,3 +1336,123 @@ def TwIST(proxg, A, b, x0, alpha=None, beta=None, eigs=None, niter=10,
         return x, j
     else:
         return x
+
+
+def DouglasRachfordSplitting(
+    proxf,
+    proxg,
+    x0,
+    tau,
+    eta=1.0,
+    niter=10,
+    gfirst=True,
+    callback=None,
+    callbacky=False,
+    show=False,
+):
+    r"""Douglas-Rachford Splitting
+
+    Solves the following minimization problem using Douglas-Rachford Splitting
+    algorithm:
+
+    .. math::
+
+        \mathbf{x} = \argmin_\mathbf{x} f(\mathbf{x}) + g(\mathbf{x})
+
+    where :math:`f(\mathbf{x})` and :math:`g(\mathbf{x})` are any convex
+    functions that has known proximal operators.
+
+    Parameters
+    ----------
+    proxf : :obj:`pyproximal.ProxOperator`
+        Proximal operator of f function
+    proxg : :obj:`pyproximal.ProxOperator`
+        Proximal operator of g function
+    x0 : :obj:`numpy.ndarray`
+        Initial vector
+    tau : :obj:`float`
+        Positive scalar weight
+    eta : :obj:`float`, optional
+        Relaxation parameter (must be between 0 and 2, 0 excluded).
+    niter : :obj:`int`, optional
+        Number of iterations of iterative scheme
+    gfirst : :obj:`bool`, optional
+        Apply Proximal of operator ``g`` first (``True``) or Proximal of
+        operator ``f`` first (``False``)
+    callback : :obj:`callable`, optional
+        Function with signature (``callback(x)``) to call after each iteration
+        where ``x`` is the current model vector
+    callbacky : :obj:`bool`, optional
+        Modify callback signature to (``callback(x, y)``)
+        when ``callbacky=True``
+    show : :obj:`bool`, optional
+        Display iterations log
+
+    Returns
+    -------
+    x : :obj:`numpy.ndarray`
+        Inverted model
+
+
+    Notes
+    -----
+    The Douglas-Rachford Splitting algorithm can be expressed by the following
+    recursion:
+
+    .. math::
+
+        \mathbf{y}^{k} &= \prox_{\tau g}(\mathbf{x}^k) \\
+        \mathbf{x}^{k+1} &= \mathbf{x}^{k} +
+        \eta (\prox_{\tau f}(2 \mathbf{y}^{k} - \mathbf{x}^{k})
+        - \mathbf{y}^{k})
+
+    .. [1] Patrick L. Combettes and Jean-Christophe Pesquet. 2011. Proximal
+        Splitting Methods in Signal Processing. In Fixed-Point Algorithms for
+        Inverse Problems in Science and Engineering, Springer, 185-212.
+        https://doi.org/10.1007/978-1-4419-9569-8_10
+    .. [2] Scott B. Lindstrom and Brailey Sims. 2021. Survey: Sixty Years of
+        Douglas-Rachford. Journal of the Australian Mathematical Society, 110,
+        3, 333-370. https://doi.org/10.1017/S1446788719000570
+        https://arxiv.org/abs/1809.07181
+
+    """
+    if show:
+        tstart = time.time()
+        print(
+            "Douglas-Rachford Splitting\n"
+            "---------------------------------------------------------\n"
+            f"Proximal operator (f): {type(proxf)}\n"
+            f"Proximal operator (g): {type(proxg)}\n"
+            f"tau = {tau:10e}\tniter = {niter:d}\n"
+        )
+        head = "   Itn       x[0]          f           g       J = f + g"
+        print(head)
+
+    x = x0.copy()
+    for iiter in range(niter):
+
+        if gfirst:
+            y = proxg.prox(x, tau)
+            x = x + eta * (proxf.prox(2 * y - x, tau) - y)
+        else:
+            y = proxf.prox(x, tau)
+            x = x + eta * (proxg.prox(2 * y - x, tau) - y)
+
+        # run callback
+        if callback is not None:
+            if callbacky:
+                callback(x, y)
+            else:
+                callback(x)
+        if show:
+            if iiter < 10 or niter - iiter < 10 or iiter % (niter // 10) == 0:
+                pf, pg = proxf(x), proxg(x)
+                print(
+                    f"{iiter + 1:6d}  {np.real(to_numpy(x[0])):12.5e}  "
+                    f"{pf:10.3e}  {pg:10.3e}  {pf + pg:10.3e}"
+                )
+
+    if show:
+        print(f"\nTotal time (s) = {time.time() - tstart:.2f}")
+        print("---------------------------------------------------------\n")
+    return x, y

--- a/pytests/test_solver.py
+++ b/pytests/test_solver.py
@@ -4,7 +4,12 @@ import numpy as np
 from numpy.testing import assert_array_almost_equal
 from pylops.basicoperators import MatrixMult
 from pyproximal.proximal import L1, L2
-from pyproximal.optimization.primal import ProximalGradient, GeneralizedProximalGradient
+from pyproximal.optimization.primal import (
+    ProximalGradient,
+    GeneralizedProximalGradient,
+    ADMM,
+    DouglasRachfordSplitting,
+)
 
 par1 = {'n': 8, 'm': 10,  'dtype': 'float32'}  # float64
 par2 = {'n': 8, 'm': 10,  'dtype': 'float64'}  # float32
@@ -72,3 +77,55 @@ def test_PG_GPG(par):
                                        acceleration='fista')
 
     assert_array_almost_equal(xpg, xgpg, decimal=2)
+
+
+@pytest.mark.parametrize("par", [(par1), (par2)])
+def test_ADMM_DRS(par):
+    """Check equivalency of ADMM and DouglasRachfordSplitting
+    when using a single regularization term
+    """
+    np.random.seed(0)
+    n, m = par['n'], par['m']
+
+    # Define sparse model
+    x = np.zeros(m)
+    x[2], x[4] = 1, 0.5
+
+    # Random mixing matrix
+    R = np.random.normal(0., 1., (n, m))
+    Rop = MatrixMult(R)
+
+    y = Rop @ x
+
+    # Step size
+    L = (Rop.H * Rop).eigs(1).real.item()
+    tau = 0.5 / L
+
+    # PG
+    l2 = L2(Op=Rop, b=y, niter=10, warm=True)
+    l1 = L1(sigma=5e-1)
+    xadmm = ADMM(
+        l2, l1, x0=np.zeros(m),
+        tau=tau, niter=100, show=True
+    )
+
+    # DRS
+    l2 = L2(Op=Rop, b=y, niter=10, warm=True)
+    l1 = L1(sigma=5e-1)
+    xdrs_g = DouglasRachfordSplitting(
+        l2, l1, x0=np.zeros(m),
+        tau=tau, niter=100, show=True,
+        gfirst=True
+    )
+
+    # DRS
+    l2 = L2(Op=Rop, b=y, niter=10, warm=True)
+    l1 = L1(sigma=5e-1)
+    xdrs_f = DouglasRachfordSplitting(
+        l2, l1, x0=np.zeros(m),
+        tau=tau, niter=100, show=True,
+        gfirst=False
+    )
+
+    assert_array_almost_equal(xadmm, xdrs_g, decimal=2)
+    assert_array_almost_equal(xadmm, xdrs_f, decimal=2)

--- a/pytests/test_solver.py
+++ b/pytests/test_solver.py
@@ -101,7 +101,7 @@ def test_ADMM_DRS(par):
     L = (Rop.H * Rop).eigs(1).real.item()
     tau = 0.5 / L
 
-    # PG
+    # ADMM
     l2 = L2(Op=Rop, b=y, niter=10, warm=True)
     l1 = L1(sigma=5e-1)
     xadmm = ADMM(
@@ -109,7 +109,7 @@ def test_ADMM_DRS(par):
         tau=tau, niter=100, show=True
     )
 
-    # DRS
+    # DRS with g first
     l2 = L2(Op=Rop, b=y, niter=10, warm=True)
     l1 = L1(sigma=5e-1)
     xdrs_g = DouglasRachfordSplitting(
@@ -118,7 +118,7 @@ def test_ADMM_DRS(par):
         gfirst=True
     )
 
-    # DRS
+    # DRS with f first
     l2 = L2(Op=Rop, b=y, niter=10, warm=True)
     l1 = L1(sigma=5e-1)
     xdrs_f = DouglasRachfordSplitting(

--- a/tutorials/nonlinearconstrained.py
+++ b/tutorials/nonlinearconstrained.py
@@ -166,6 +166,24 @@ xinv_admm = pyproximal.optimization.primal.ADMM(fnl, ind,
 xhist_admm = np.array(xhist)
 
 ###############################################################################
+# And using the Douglas-Rachford Splitting solver
+
+fnl = Rosebrock(niter=20, x0=np.zeros(2), warm=True)
+fnl.setup(1, 10, alpha=0.02)
+ind = pyproximal.proximal.Box(lower, upper)
+
+x0 = np.array([0, 0])
+
+xhist = [x0,]
+xinv_dr = pyproximal.optimization.primal.DouglasRachfordSplitting(
+    fnl, ind,
+    tau=1.,
+    x0=x0,
+    niter=30, show=True,
+    callback=callback)
+xhist_dr = np.array(xhist)
+
+###############################################################################
 # To conclude it is important to notice that whilst we implemented a vanilla
 # gradient descent inside the optimize method, any more advanced solver can
 # be used (here for example we will repeat the same exercise using L-BFGS from
@@ -202,6 +220,24 @@ xinv_admm_lbfgs = pyproximal.optimization.primal.ADMM(fnl, ind,
 xhist_admm_lbfgs = np.array(xhist)
 
 ###############################################################################
+# And using the Douglas-Rachford Splitting solver
+
+fnl = Rosebrock_lbfgs(niter=20, x0=np.zeros(2), warm=True)
+fnl.setup(1, 10, alpha=0.02)
+ind = pyproximal.proximal.Box(lower, upper)
+
+x0 = np.array([0, 0])
+
+xhist = [x0,]
+xinv_dr_lbfgs = pyproximal.optimization.primal.DouglasRachfordSplitting(
+    fnl, ind,
+    tau=1.,
+    x0=x0,
+    niter=30, show=True,
+    callback=callback)
+xhist_dr_lbfgs = np.array(xhist)
+
+###############################################################################
 # Finally let's compare the results.
 
 fig, ax = contour_rosenbrock(x, y)
@@ -213,8 +249,25 @@ ax.plot(xhist_pg[:, 0], xhist_pg[:, 1], '.-b', ms=20, lw=2, label='PG')
 ax.plot(xhist_admm[:, 0], xhist_admm[:, 1], '.-g', ms=20, lw=2, label='ADMM')
 ax.plot(xhist_admm_lbfgs[:, 0], xhist_admm_lbfgs[:, 1], '.-m', ms=20, lw=2,
         label='ADMM with LBFGS')
+ax.plot(xhist_dr[:, 0], xhist_dr[:, 1], ".--y", ms=20, lw=2, label="DR")
+ax.plot(xhist_dr_lbfgs[:, 0], xhist_dr_lbfgs[:, 1], ".--r", ms=20, lw=2,
+        label="DR with LBFGS")
 ax.set_title('Rosenbrock optimization')
 ax.legend()
 ax.set_xlim(x[0], x[-1])
 ax.set_ylim(y[0], y[-1])
 fig.tight_layout()
+
+###############################################################################
+# Let's see the minimizer and minimum.
+
+print("name                 xopt                    f(xopt)")
+for hist, name in [
+    (xhist_pg, "PG"),
+    (xhist_admm, "ADMM"),
+    (xhist_admm_lbfgs, "ADMM with LBFGS"),
+    (xhist_dr, "DR"),
+    (xhist_dr_lbfgs, "DR with LBFGS"),
+]:
+    xopt = hist[-1]
+    print(f"{name:20s} {xopt} {fnl(xopt)}")


### PR DESCRIPTION
I added the Douglas-Rachford Splitting (DRS), a well-known splitting method.

In pyproximal.optimization.primal.ADMM, DRS is mentioned as:

> Solves the following minimization problem using Alternating Direction Method of Multipliers (also known as Douglas-Rachford splitting):

However, DRS is a dual ADMM and I think it would be better to include this well-known method for beginners who are familiar with basic methods in textbooks such as primal DRS.