### PR TITLE
minor: added logging to __init__

### DIFF
--- a/pyproximal/__init__.py
+++ b/pyproximal/__init__.py
@@ -24,6 +24,8 @@ utils
 
 """
 
+import logging
+
 from .ProxOperator import ProxOperator
 from .proximal import *
 
@@ -32,12 +34,14 @@ from .utils.utils import Report
 from . import proximal
 from . import optimization
 
+# Prevent no handler message if an application using PyProximal does not configure logging
+logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 try:
     from .version import version as __version__
 except ImportError:
     # If it was not installed, then we don't know the version. We could throw a
-    # warning here, but this case *should* be rare. pylops should be installed
+    # warning here, but this case *should* be rare. PyProximal should be installed
     # properly!
     from datetime import datetime
     __version__ = 'unknown-'+datetime.today().strftime('%Y%m%d')


### PR DESCRIPTION
This PR adds a logging command to `__init__` to avoid a warning message if an application using PyProximal does not configure logging.