### PR TITLE
bugfix of proximal.L1

### DIFF
--- a/pyproximal/proximal/L1.py
+++ b/pyproximal/proximal/L1.py
@@ -116,7 +116,9 @@ class L1(ProxOperator):
 
     def __call__(self, x: NDArray) -> float:
         sigma = _current_sigma(self.sigma, self.count)
-        return float(sigma * np.sum(np.abs(x)))
+        if self.g is None:
+            return float(sigma * np.sum(np.abs(x)))
+        return float(sigma * np.sum(np.abs(x - self.g)))
 
     def _increment_count(func: Callable[..., Any]) -> Callable[..., Any]:
         """Increment counter"""

--- a/pytests/test_norms.py
+++ b/pytests/test_norms.py
@@ -174,13 +174,12 @@ def test_L1(par):
 @pytest.mark.parametrize("par", [(par1), (par2)])
 def test_L1_diff(par):
     """L1 norm of difference and proximal/dual proximal"""
-    l1 = L1(
-        sigma=par["sigma"], g=np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
-    )
+    g = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
+    l1 = L1(sigma=par["sigma"], g=g)
 
     # norm
     x = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
-    assert l1(x) == par["sigma"] * np.sum(np.abs(x))
+    assert l1(x) == par["sigma"] * np.sum(np.abs(x - g))
 
     # prox / dualprox
     tau = 2.0


### PR DESCRIPTION
I found a small bug and fixed it.

- add subtracting `self.g` in `__call__()`
- fix `test_L1_diff()` by subtracting `g`

This is a refined version of #220.