### PR TITLE
feat[BREAKING]: initial guess of auxiliary variable

### DIFF
--- a/pyproximal/optimization/primal.py
+++ b/pyproximal/optimization/primal.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Un
 
 import numpy as np
 from pylops.optimization.leastsquares import regularized_inversion
-from pylops.utils.backend import to_numpy
+from pylops.utils.backend import get_array_module, to_numpy
 from pylops.utils.typing import NDArray
 
 from pyproximal.proximal import L2
@@ -48,6 +48,39 @@ def _backtracking(
         tau *= beta
         iiterback += 1
     return z, tau
+
+
+def _x0z0_init(x0, z0, Op=None, z0name="z0", Opname="Op"):
+    r"""Initialize x0 and z0
+
+    Initialize x0 and z0 using the following convention.
+
+    For ``Op=None``:
+    - if both are provided, they are simply returned;
+    - if only one is provided (the other is None), the one provided is also
+      copied to the other one.
+
+    For ``Op!=None``, ``x0`` must be provided, and:
+    - if both are provided, they are simply returned;
+    - if ``z0`` is not provided, set to ``Op @ x0``.
+
+    """
+    if x0 is None and z0 is None:
+        raise ValueError(
+            f"Both x0 or {z0name} are None, provide either of them or both"
+        )
+
+    if Op is None:
+        if x0 is None:
+            x0 = z0.copy()
+        elif z0 is None:
+            z0 = x0.copy()
+    else:
+        if x0 is None:
+            raise ValueError(f"x0 must be provided when {Opname} is also provided")
+        elif z0 is None:
+            z0 = Op @ x0
+    return x0, z0
 
 
 def ProximalPoint(
@@ -875,15 +908,15 @@ def HQS(
     proxg : :obj:`pyproximal.ProxOperator`
         Proximal operator of g function
     x0 : :obj:`numpy.ndarray`
-        Initial vector
-    tau : :obj:`float` or :obj:`numpy.ndarray`, optional
+        Initial vector (not required when ``gfirst=False``, can pass ``None``)
+    tau : :obj:`float` or :obj:`numpy.ndarray`
         Positive scalar weight, which should satisfy the following condition
         to guarantees convergence: :math:`\tau  \in (0, 1/L]` where ``L`` is
         the Lipschitz constant of :math:`\nabla f`. Finally note that
         :math:`\tau` can be chosen to be a vector of size ``niter`` such that
         different :math:`\tau` is used at different iterations (i.e., continuation
         strategy)
-    niter : :obj:`int`, optional
+    niter : :obj:`int`
         Number of iterations of iterative scheme
     z0 : :obj:`numpy.ndarray`, optional
         Initial z vector (not required when ``gfirst=True``)
@@ -904,6 +937,11 @@ def HQS(
         Inverted model
     z : :obj:`numpy.ndarray`
         Inverted second model
+
+    Raises
+    ------
+    ValueError
+        If both ``x0`` and ``z0`` are set to ``None``
 
     Notes
     -----
@@ -931,9 +969,13 @@ def HQS(
          4, 7, pp. 932-946, 1995.
 
     """
+    # initialize variables
+    x, z = _x0z0_init(x0, z0)
+    ncp = get_array_module(x)
+
     # check if tau is a vector
-    tau = np.asarray(tau, dtype=float)
-    if tau.size == 1.0:
+    tau = ncp.asarray(tau, dtype=float)
+    if tau.size == 1:
         tau_print = str(tau)
         tau = tau * np.ones(niter)
     else:
@@ -951,11 +993,7 @@ def HQS(
         head = "   Itn       x[0]          f           g       J = f + g"
         print(head)
 
-    x = x0.copy()
-    if z0 is not None:
-        z = z0.copy()
-    else:
-        z = np.zeros_like(x)
+    # run iterations
     for iiter in range(niter):
         if gfirst:
             z = proxg.prox(x, tau[iiter])
@@ -994,6 +1032,7 @@ def ADMM(
     x0: NDArray,
     tau: float,
     niter: int = 10,
+    z0: Optional[NDArray] = None,
     gfirst: bool = False,
     callback: Optional[Callable[..., None]] = None,
     callbackz: bool = False,
@@ -1036,13 +1075,15 @@ def ADMM(
     proxg : :obj:`pyproximal.ProxOperator`
         Proximal operator of g function
     x0 : :obj:`numpy.ndarray`
-        Initial vector
-    tau : :obj:`float`, optional
+        Initial vector (not required when ``gfirst=False``, can pass ``None``)
+    tau : :obj:`float`
         Positive scalar weight, which should satisfy the following condition
         to guarantees convergence: :math:`\tau  \in (0, 1/L]` where ``L`` is
         the Lipschitz constant of :math:`\nabla f`.
-    niter : :obj:`int`, optional
+    niter : :obj:`int`
         Number of iterations of iterative scheme
+    z0 : :obj:`numpy.ndarray`, optional
+        Initial z vector (not required when ``gfirst=True``)
     gfirst : :obj:`bool`, optional
         Apply Proximal of operator ``g`` first (``True``) or Proximal of
         operator ``f`` first (``False``)
@@ -1066,6 +1107,11 @@ def ADMM(
     ADMML2: ADMM with L2 misfit function
     LinearizedADMM: Linearized ADMM
 
+    Raises
+    ------
+    ValueError
+        If both ``x0`` and ``z0`` are set to ``None``
+
     Notes
     -----
     The ADMM algorithm can be expressed by the following recursion [1]_:
@@ -1087,6 +1133,12 @@ def ADMM(
         Learning, 3 (1), 1-122. https://doi.org/10.1561/2200000016.
 
     """
+    # initialize variables
+    x, z = _x0z0_init(x0, z0)
+    ncp = get_array_module(x)
+    # TODO: Clarify what is the best choice for u
+    u = ncp.zeros_like(x)
+
     if show:
         tstart = time.time()
         print(
@@ -1099,8 +1151,7 @@ def ADMM(
         head = "   Itn       x[0]          f           g       J = f + g"
         print(head)
 
-    x = x0.copy()
-    u = z = np.zeros_like(x)
+    # run iterations
     for iiter in range(niter):
         if gfirst:
             z = proxg.prox(x + u, tau)
@@ -1141,6 +1192,7 @@ def ADMML2(
     x0: NDArray,
     tau: float,
     niter: int = 10,
+    z0: Optional[NDArray] = None,
     gfirst: bool = False,
     callback: Optional[Callable[[NDArray], None]] = None,
     show: bool = False,
@@ -1171,11 +1223,13 @@ def ADMML2(
         Linear operator of regularization term
     x0 : :obj:`numpy.ndarray`
         Initial vector
-    tau : :obj:`float`, optional
+    tau : :obj:`float`
         Positive scalar weight, which should satisfy the following condition
         to guarantees convergence: :math:`\tau \in (0, 1/\lambda_{max}(\mathbf{A}^H\mathbf{A})]`.
     niter : :obj:`int`, optional
         Number of iterations of iterative scheme
+    z0 : :obj:`numpy.ndarray`
+        Initial auxiliary vector. If ``None``, initialized to ``A @ x0``.
     gfirst : :obj:`bool`, optional
         Apply Proximal of operator ``g`` first (``True``) or Proximal of
         operator ``f`` first (``False``)
@@ -1212,6 +1266,10 @@ def ADMML2(
         \mathbf{u}^{k+1} = \mathbf{u}^{k} + \mathbf{Ax}^{k+1} - \mathbf{z}^{k+1}
 
     """
+    # initialize variables
+    x, z = _x0z0_init(x0, z0, A, Opname="A")
+    u = z.copy()
+
     if show:
         tstart = time.time()
         print(
@@ -1223,9 +1281,8 @@ def ADMML2(
         head = "   Itn       x[0]          f           g       J = f + g"
         print(head)
 
+    # run iterations
     sqrttau = 1.0 / sqrt(tau)
-    x = x0.copy()
-    u = z = np.zeros(A.shape[0], dtype=A.dtype)
     for iiter in range(niter):
         if gfirst:
             Ax = A @ x
@@ -1297,6 +1354,7 @@ def LinearizedADMM(
     tau: float,
     mu: float,
     niter: int = 10,
+    z0: Optional[NDArray] = None,
     callback: Optional[Callable[[NDArray], None]] = None,
     show: bool = False,
 ) -> Tuple[NDArray, NDArray]:
@@ -1333,6 +1391,8 @@ def LinearizedADMM(
         \tau/\lambda_{max}(\mathbf{A}^H\mathbf{A})]`.
     niter : :obj:`int`, optional
         Number of iterations of iterative scheme
+    z0 : :obj:`numpy.ndarray`
+        Initial auxiliary vector. If ``None``, initialized to ``A @ x0``.
     callback : :obj:`callable`, optional
         Function with signature (``callback(x)``) to call after each iteration
         where ``x`` is the current model vector
@@ -1368,6 +1428,13 @@ def LinearizedADMM(
         in Optimization. 2013.
 
     """
+    # initialize variables
+    x, z = _x0z0_init(x0, z0, A, Opname="A")
+    Ax = A.matvec(x) if z0 is None else z
+    ncp = get_array_module(x)
+    # TODO: Clarify what is the best choice for u
+    u = ncp.zeros_like(z)
+
     if show:
         tstart = time.time()
         print(
@@ -1381,9 +1448,8 @@ def LinearizedADMM(
         )
         head = "   Itn       x[0]          f           g       J = f + g"
         print(head)
-    x = x0.copy()
-    Ax = A.matvec(x)
-    u = z = np.zeros_like(Ax)
+
+    # run iterations
     for iiter in range(niter):
         x = proxf.prox(x - mu / tau * A.rmatvec(Ax - z + u), mu)
         Ax = A.matvec(x)

--- a/pyproximal/optimization/primal.py
+++ b/pyproximal/optimization/primal.py
@@ -1268,7 +1268,9 @@ def ADMML2(
     """
     # initialize variables
     x, z = _x0z0_init(x0, z0, A, Opname="A")
-    u = z.copy()
+    ncp = get_array_module(x)
+    # TODO: Clarify what is the best choice for u
+    u = ncp.zeros_like(z)
 
     if show:
         tstart = time.time()

--- a/pyproximal/optimization/primal.py
+++ b/pyproximal/optimization/primal.py
@@ -50,7 +50,13 @@ def _backtracking(
     return z, tau
 
 
-def _x0z0_init(x0, z0, Op=None, z0name="z0", Opname="Op"):
+def _x0z0_init(
+    x0: NDArray | None,
+    z0: NDArray | None,
+    Op: Optional["LinearOperator"] = None,
+    z0name: Optional[str] = "z0",
+    Opname: Optional[str] = "Op",
+) -> Tuple[NDArray, NDArray]:
     r"""Initialize x0 and z0
 
     Initialize x0 and z0 using the following convention.
@@ -64,6 +70,19 @@ def _x0z0_init(x0, z0, Op=None, z0name="z0", Opname="Op"):
     - if both are provided, they are simply returned;
     - if ``z0`` is not provided, set to ``Op @ x0``.
 
+    Parameters
+    ----------
+    x0 : :obj:`numpy.ndarray`
+        Initial vector
+    z0 : :obj:`numpy.ndarray`
+        Initial auxiliary vector
+    Op : :obj:`pylops.LinearOperator`, optional
+        Linear Operator to apply to ``x0``
+    z0name : :obj:`str`, optional
+        Name to display in error message instead of ``z0``
+    Opname : :obj:`str`, optional
+        Name to display in error message instead of ``Op``
+
     """
     if x0 is None and z0 is None:
         raise ValueError(
@@ -72,7 +91,7 @@ def _x0z0_init(x0, z0, Op=None, z0name="z0", Opname="Op"):
 
     if Op is None:
         if x0 is None:
-            x0 = z0.copy()
+            x0 = z0.copy()  # type: ignore[union-attr]
         elif z0 is None:
             z0 = x0.copy()
     else:
@@ -1136,7 +1155,6 @@ def ADMM(
     # initialize variables
     x, z = _x0z0_init(x0, z0)
     ncp = get_array_module(x)
-    # TODO: Clarify what is the best choice for u
     u = ncp.zeros_like(x)
 
     if show:
@@ -1249,6 +1267,11 @@ def ADMML2(
     z : :obj:`numpy.ndarray`
         Inverted second model
 
+    Raises
+    ------
+    ValueError
+        If both ``x0`` and ``z0`` are set to ``None`` or ``x0`` is set to None
+
     See Also
     --------
     ADMM: ADMM
@@ -1269,7 +1292,6 @@ def ADMML2(
     # initialize variables
     x, z = _x0z0_init(x0, z0, A, Opname="A")
     ncp = get_array_module(x)
-    # TODO: Clarify what is the best choice for u
     u = ncp.zeros_like(z)
 
     if show:
@@ -1408,6 +1430,11 @@ def LinearizedADMM(
     z : :obj:`numpy.ndarray`
         Inverted second model
 
+    Raises
+    ------
+    ValueError
+        If both ``x0`` and ``z0`` are set to ``None``
+
     See Also
     --------
     ADMM: ADMM
@@ -1434,7 +1461,6 @@ def LinearizedADMM(
     x, z = _x0z0_init(x0, z0, A, Opname="A")
     Ax = A.matvec(x) if z0 is None else z
     ncp = get_array_module(x)
-    # TODO: Clarify what is the best choice for u
     u = ncp.zeros_like(z)
 
     if show:

--- a/pyproximal/optimization/primal.py
+++ b/pyproximal/optimization/primal.py
@@ -57,8 +57,8 @@ def _x0z0_init(x0, z0, Op=None, z0name="z0", Opname="Op"):
 
     For ``Op=None``:
     - if both are provided, they are simply returned;
-    - if only one is provided (the other is None), the one provided is also
-      copied to the other one.
+    - if only one is provided (the other is ``None``), the one provided
+      is copied to the other one.
 
     For ``Op!=None``, ``x0`` must be provided, and:
     - if both are provided, they are simply returned;

--- a/pyproximal/optimization/primaldual.py
+++ b/pyproximal/optimization/primaldual.py
@@ -5,7 +5,6 @@ import numpy as np
 from pylops.utils.backend import get_array_module, to_numpy
 from pylops.utils.typing import NDArray
 
-from pyproximal.optimization.primal import _x0z0_init
 from pyproximal.ProxOperator import ProxOperator
 
 if TYPE_CHECKING:
@@ -71,7 +70,7 @@ def PrimalDual(
         Stepsize of subgradient of :math:`g^*`. This can be constant
         or function of iterations (in the latter cases provided as np.ndarray)
     y0 : :obj:`numpy.ndarray`
-        Initial auxiliary vector. If ``None``, initialized to ``A @ x0``.
+        Initial auxiliary vector. If ``None``, set to zero
     z : :obj:`numpy.ndarray`, optional
         Additional vector
     theta : :obj:`float`
@@ -133,10 +132,7 @@ def PrimalDual(
         Imaging and Vision, 40, 8pp. 120-145. 2011.
 
     """
-    # initialize variables
-    x, y = _x0z0_init(x0, y0, A, z0name="y0", Opname="A")
-    xhat = x.copy()
-    ncp = get_array_module(x)
+    ncp = get_array_module(x0)
 
     # check if tau and mu are scalars or arrays
     fixedtau = fixedmu = False
@@ -170,6 +166,11 @@ def PrimalDual(
         )
         head = "   Itn       x[0]          f           g          z^x       J = f + g + z^x"
         print(head)
+
+    # initialize variables
+    x = x0.copy()
+    y = y0.copy() if y0 is not None else ncp.zeros(A.shape[0], dtype=x.dtype)
+    xhat = x.copy()
 
     # run iterations
     for iiter in range(niter):

--- a/pyproximal/optimization/primaldual.py
+++ b/pyproximal/optimization/primaldual.py
@@ -5,6 +5,7 @@ import numpy as np
 from pylops.utils.backend import get_array_module, to_numpy
 from pylops.utils.typing import NDArray
 
+from pyproximal.optimization.primal import _x0z0_init
 from pyproximal.ProxOperator import ProxOperator
 
 if TYPE_CHECKING:
@@ -70,7 +71,7 @@ def PrimalDual(
         Stepsize of subgradient of :math:`g^*`. This can be constant
         or function of iterations (in the latter cases provided as np.ndarray)
     y0 : :obj:`numpy.ndarray`
-        Initial auxiliary vector
+        Initial auxiliary vector. If ``None``, initialized to ``A @ x0``.
     z : :obj:`numpy.ndarray`, optional
         Additional vector
     theta : :obj:`float`
@@ -132,7 +133,10 @@ def PrimalDual(
         Imaging and Vision, 40, 8pp. 120-145. 2011.
 
     """
-    ncp = get_array_module(x0)
+    # initialize variables
+    x, y = _x0z0_init(x0, y0, A, z0name="y0", Opname="A")
+    xhat = x.copy()
+    ncp = get_array_module(x)
 
     # check if tau and mu are scalars or arrays
     fixedtau = fixedmu = False
@@ -167,9 +171,7 @@ def PrimalDual(
         head = "   Itn       x[0]          f           g          z^x       J = f + g + z^x"
         print(head)
 
-    x = x0.copy()
-    xhat = x.copy()
-    y = y0.copy() if y0 is not None else ncp.zeros(A.shape[0], dtype=x.dtype)
+    # run iterations
     for iiter in range(niter):
         xold = x.copy()
         if gfirst:

--- a/pytests/test_solver.py
+++ b/pytests/test_solver.py
@@ -51,6 +51,7 @@ def test_ADMML2_noinitial():
     is provided to PrimalDual solver
     """
     with pytest.raises(ValueError):
+        # Both None
         _ = ADMML2(
             proxg=L1(),
             Op=Identity(10),
@@ -60,6 +61,17 @@ def test_ADMML2_noinitial():
             x0=None,
             z0=None,
         )
+    with pytest.raises(ValueError):
+        # x0 is None (and Op provided)
+        _ = ADMML2(
+            proxg=L1(),
+            Op=Identity(10),
+            b=np.ones(10),
+            A=Identity(10),
+            tau=1.0,
+            x0=None,
+            z0=np.ones(10),
+        )
 
 
 def test_LinearizedADMM_noinitial():
@@ -67,6 +79,7 @@ def test_LinearizedADMM_noinitial():
     is provided to LinearizedADMM solver
     """
     with pytest.raises(ValueError):
+        # Both None
         _ = LinearizedADMM(
             proxf=L2(),
             proxg=L1(),
@@ -75,6 +88,17 @@ def test_LinearizedADMM_noinitial():
             mu=1.0,
             x0=None,
             z0=None,
+        )
+    with pytest.raises(ValueError):
+        # x0 is None (and Op provided)
+        _ = LinearizedADMM(
+            proxf=L2(),
+            proxg=L1(),
+            A=Identity(10),
+            tau=1.0,
+            mu=1.0,
+            x0=None,
+            z0=np.ones(10),
         )
 
 

--- a/pytests/test_solver.py
+++ b/pytests/test_solver.py
@@ -48,7 +48,7 @@ def test_ADMM_noinitial():
 
 
 def test_ADMML2_noinitial():
-    """Check that an error is raised if no initial x0
+    """Check that an error is raised if no initial value
     is provided to PrimalDual solver
     """
     with pytest.raises(ValueError):
@@ -57,8 +57,9 @@ def test_ADMML2_noinitial():
             Op=Identity(10),
             b=np.ones(10),
             A=Identity(10),
-            x0=None,
             tau=1.0,
+            x0=None,
+            z0=None,
         )
 
 
@@ -71,24 +72,10 @@ def test_LinearizedADMM_noinitial():
             proxf=L2(),
             proxg=L1(),
             A=Identity(10),
-            x0=None,
             tau=1.0,
             mu=1.0,
-        )
-
-
-def test_PrimalDual_noinitial():
-    """Check that an error is raised if no initial x0
-    is provided to PrimalDual solver
-    """
-    with pytest.raises(ValueError):
-        _ = PrimalDual(
-            proxf=L2(),
-            proxg=L1(),
-            A=Identity(10),
             x0=None,
-            tau=1.0,
-            mu=1.0,
+            z0=None,
         )
 
 

--- a/pytests/test_solver.py
+++ b/pytests/test_solver.py
@@ -1,18 +1,95 @@
 import numpy as np
 import pytest
 from numpy.testing import assert_array_almost_equal
-from pylops.basicoperators import MatrixMult
+from pylops.basicoperators import Identity, MatrixMult
 
 from pyproximal.optimization.primal import (
     ADMM,
+    ADMML2,
+    HQS,
     DouglasRachfordSplitting,
     GeneralizedProximalGradient,
+    LinearizedADMM,
     ProximalGradient,
 )
+from pyproximal.optimization.primaldual import PrimalDual
 from pyproximal.proximal import L1, L2
 
 par1 = {"n": 8, "m": 10, "dtype": "float32"}  # float64
 par2 = {"n": 8, "m": 10, "dtype": "float64"}  # float32
+
+
+def test_HQS_noinitial():
+    """Check that an error is raised if no initial value
+    is provided to HQS solver
+    """
+    with pytest.raises(ValueError):
+        _ = HQS(
+            proxf=L2(),
+            proxg=L1(),
+            tau=1.0,
+            x0=None,
+            z0=None,
+        )
+
+
+def test_ADMM_noinitial():
+    """Check that an error is raised if no initial value
+    is provided to ADMM solver
+    """
+    with pytest.raises(ValueError):
+        _ = ADMM(
+            proxf=L2(),
+            proxg=L1(),
+            tau=1.0,
+            x0=None,
+            z0=None,
+        )
+
+
+def test_ADMML2_noinitial():
+    """Check that an error is raised if no initial x0
+    is provided to PrimalDual solver
+    """
+    with pytest.raises(ValueError):
+        _ = ADMML2(
+            proxg=L1(),
+            Op=Identity(10),
+            b=np.ones(10),
+            A=Identity(10),
+            x0=None,
+            tau=1.0,
+        )
+
+
+def test_LinearizedADMM_noinitial():
+    """Check that an error is raised if no initial x0
+    is provided to LinearizedADMM solver
+    """
+    with pytest.raises(ValueError):
+        _ = LinearizedADMM(
+            proxf=L2(),
+            proxg=L1(),
+            A=Identity(10),
+            x0=None,
+            tau=1.0,
+            mu=1.0,
+        )
+
+
+def test_PrimalDual_noinitial():
+    """Check that an error is raised if no initial x0
+    is provided to PrimalDual solver
+    """
+    with pytest.raises(ValueError):
+        _ = PrimalDual(
+            proxf=L2(),
+            proxg=L1(),
+            A=Identity(10),
+            x0=None,
+            tau=1.0,
+            mu=1.0,
+        )
 
 
 @pytest.mark.parametrize("par", [(par1), (par2)])

--- a/pytests/test_solver.py
+++ b/pytests/test_solver.py
@@ -12,7 +12,6 @@ from pyproximal.optimization.primal import (
     LinearizedADMM,
     ProximalGradient,
 )
-from pyproximal.optimization.primaldual import PrimalDual
 from pyproximal.proximal import L1, L2
 
 par1 = {"n": 8, "m": 10, "dtype": "float32"}  # float64


### PR DESCRIPTION
**[BREAKING CHANGE]**

This PR adds support for initializing also the auxiliary variable in various solvers, and modified logic for internal initialization based on whether `x0` or `z0/y0` is provided, based on https://github.com/PyLops/pyproximal/issues/222.

More specifically:
- `HQS`: makes x0=z0 or z0=x0 if either is passed.
- `ADMM`: makes x0=z0 or z0=x0 if either is passed and chooses `u=0` (so far seems the best solution based on some numerical examples - also tried u=z0 but did not give good results, and I think it makes sense as it is the Lagrangian - **any opinion?**)
- `ADMML2`: makes z0=Ax0 if z0 is not passed, however it forces one to pass `x0` a from `z0` one can't really define `x0` (would be `A^-1z0`...). Same as ADMM, chooses `u=0`.
- `LinearizedADMM`: same as `ADMML2`.

This is all done using the same auxiliary method `_x0z0_init`, which always raises a `ValueError` exception if both `x0` and `z0` are None.

Note: this is a **breaking change** as currently we tend to initialize some of the auxiliary variables to zero no matter the provided value for the main variable. Whilst changing the way we initialize the auxiliary variables changes the behavior of the solver (for all cases but that of zero initialization) both the explanation and example provided in https://github.com/PyLops/pyproximal/issues/222 and some of the examples discuss below seem to suggest that what we have is suboptimal (borderline a bug) a worth changing for the best!

Note1: I also tried implementing a similar strategy for `PrimalDual` but results on some numerical examples started to be very bad. I think this is because the theory of this solver is not based on a splitting (for which it makes sense to start x=z in ADMM like solvers, and in fact I checked that at convergence y and Ax are not close (whilst again this is the case for ADMM solvers that support g(Ax)).

Note2: I initially wanted to also make `x0` optional but then I realized that a few tutorials were breaking because of the fact that I had to move x0 after other positional arguments and there I was calling the solver with x0 at its original location. Since I find this too much of a non-backward compatible behavior, so I decided to still keep x0 positional and where it makes sense to pass None (case when x0 isn't used, then I described this in the docstring).
