### PR TITLE
fix the Box indicator function

### DIFF
--- a/pyproximal/proximal/Box.py
+++ b/pyproximal/proximal/Box.py
@@ -38,7 +38,7 @@ class Box(ProxOperator):
         self.box = BoxProj(self.lower, self.upper)
 
     def __call__(self, x: NDArray) -> bool:
-        return bool(np.all((x > self.lower) & (x < self.upper)))
+        return bool(np.all((x >= self.lower) & (x <= self.upper)))
 
     @_check_tau
     def prox(self, x: NDArray, tau: float) -> NDArray:

--- a/pytests/test_projection.py
+++ b/pytests/test_projection.py
@@ -35,6 +35,9 @@ def test_Box(par):
     tau = 2.0
     assert moreau(box, x, tau)
 
+    x_proj = box.prox(x, tau)
+    assert box(x_proj)
+
 
 @pytest.mark.parametrize(
     "par",

--- a/pytests/test_projection.py
+++ b/pytests/test_projection.py
@@ -31,12 +31,14 @@ def test_Box(par):
     box = Box(-1, 1)
     x = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
 
+    # evaluation
+    assert box(x) is False
+    xp = box.prox(x, 1.0)
+    assert box(xp) is True
+
     # prox / dualprox
     tau = 2.0
     assert moreau(box, x, tau)
-
-    x_proj = box.prox(x, tau)
-    assert box(x_proj)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
I found a small bug.

- old: `(x > self.lower) & (x < self.upper)`
- fix: `(x >= self.lower) & (x <= self.upper)`

Also I added a test for this.