### PR TITLE
v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+# 0.11.1
+* Added ``typing_extensions`` to dependencies
+
 # 0.11.0
 * Added ``pyproximal.optimization.primal.DouglasRachfordSplitting``
   solver

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3,6 +3,12 @@
 Changelog
 =========
 
+Version 0.11.1
+--------------
+*Released on: 25/11/2025*
+
+* Added ``typing_extensions`` to dependencies
+
 Version 0.11.0
 --------------
 *Released on: 24/11/2025*

--- a/environment-dev-arm.yml
+++ b/environment-dev-arm.yml
@@ -10,6 +10,7 @@ dependencies:
   - pylops>=2.0.0
   - scikit-image
   - matplotlib
+  - typing_extensions
   - ipython
   - pytest
   - Sphinx

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -10,6 +10,7 @@ dependencies:
   - pylops>=2.0.0
   - scikit-image
   - matplotlib
+  - typing_extensions
   - ipython
   - pytest
   - Sphinx

--- a/environment.yml
+++ b/environment.yml
@@ -6,3 +6,4 @@ dependencies:
   - numpy>=1.21.0
   - scipy>=1.14.0
   - pylops>=2.0.0
+  - typing_extensions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "numpy >= 1.21.0",
     "scipy >= 1.11.0",
     "pylops >= 2.0.0",
+    "typing_extensions",
 ]
 dynamic = ["version"]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,7 @@ matplotlib
 ipython
 bm4d<4.2.4 # temporary as gclib problem arises in readthedocs
 bm3d<4.0.2 # temporary as gclib problem arises in readthedocs
+typing_extensions
 pytest
 pytest-runner
 setuptools_scm

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -7,6 +7,7 @@ matplotlib
 ipython
 bm4d<4.2.4 # temporary as gclib problem arises in readthedocs
 bm3d<4.0.2 # temporary as gclib problem arises in readthedocs
+typing_extensions
 pytest
 pytest-runner
 setuptools_scm


### PR DESCRIPTION
This PR fixes a problem that arose when conda-forge tried to build our previous release (v0.11.0): turns out that we started to use `typing_extensions` but did not add it to the dependencies, our CI did not mind (likely it comes already with the Python used in GA and AzurePipelines)...  

`typing_extensions` is now added to `pyproject.toml` and all environment files.