### PR TITLE
test: increase test coverage

### DIFF
--- a/pyproximal/proximal/L2.py
+++ b/pyproximal/proximal/L2.py
@@ -359,9 +359,9 @@ class L2Convolve(ProxOperator):
             self.dir = -1
         else:
             self.dir = (
-                len(self.dims) - 1
+                len(dims) - 1
                 if dir is None
-                else get_normalize_axis_index()(dir, len(self.dims))
+                else get_normalize_axis_index()(dir, len(dims))
             )
 
         # convert data and filter to Fourier domain

--- a/pyproximal/proximal/L2.py
+++ b/pyproximal/proximal/L2.py
@@ -5,7 +5,11 @@ import numpy as np
 from pylops import Identity, MatrixMult
 from pylops.optimization.basic import cg, lsqr
 from pylops.optimization.leastsquares import regularized_inversion
-from pylops.utils.backend import get_array_module, get_module_name
+from pylops.utils.backend import (
+    get_array_module,
+    get_module_name,
+    get_normalize_axis_index,
+)
 from pylops.utils.typing import NDArray, ShapeLike
 from scipy.linalg import cho_factor, cho_solve
 from scipy.sparse.linalg import lsqr as sp_lsqr
@@ -351,23 +355,31 @@ class L2Convolve(ProxOperator):
         self.nfft = nfft
         self.sigma = sigma
         self.dims = dims
-        self.dir = -1 if dir is None else dir
+        if dims is None:
+            self.dir = -1
+        else:
+            self.dir = (
+                len(self.dims) - 1
+                if dir is None
+                else get_normalize_axis_index()(dir, len(self.dims))
+            )
 
         # convert data and filter to Fourier domain
         self.bf = np.fft.fft(b, self.nfft, axis=self.dir)
-        self.hf = np.fft.fft(h, self.nfft, axis=self.dir)
+        self.hf = np.fft.fft(h, self.nfft, axis=0 if h.ndim == 1 else self.dir)
 
         # expand dimensions of filters
         if self.dims is not None:
-            self.bf = self.bf.reshape(self.dims)
             self.dimsf = list(self.dims).copy()
             self.dimsf[self.dir] = nfft
+            self.bf = self.bf.reshape(self.dimsf)
 
             ndims = len(self.dims)
-            for _ in range(self.dir - 1):
-                self.hf = np.expand_dims(self.hf, axis=0)
-            for _ in range(ndims - self.dir - 1):
-                self.hf = np.expand_dims(self.hf, axis=-1)
+            if self.hf.ndim == 1:
+                for _ in range(self.dir):
+                    self.hf = np.expand_dims(self.hf, axis=0)
+                for _ in range(ndims - self.dir - 1):
+                    self.hf = np.expand_dims(self.hf, axis=-1)
 
         # precompute terms for prox
         self.hbf = np.conj(self.hf) * self.bf
@@ -393,14 +405,16 @@ class L2Convolve(ProxOperator):
             y = y[: len(x)]
         else:
             y = np.take(y, range(self.dims[self.dir]), axis=self.dir).ravel()
-        return y.ravel()
+        return y
 
     def grad(self, x: NDArray) -> NDArray:
         if self.dims is not None:
             x = x.reshape(self.dims)
         xf = np.fft.fft(x, self.nfft, axis=self.dir)
 
-        f = self.sigma * np.fft.ifft(
+        g = self.sigma * np.fft.ifft(
             np.conj(self.hf) * (self.hf * xf - self.bf), axis=self.dir
         )
-        return f.ravel()
+        g = np.take(g, range(x.shape[self.dir]), axis=self.dir).ravel()
+
+        return g

--- a/pyproximal/proximal/Orthogonal.py
+++ b/pyproximal/proximal/Orthogonal.py
@@ -73,7 +73,7 @@ class Orthogonal(ProxOperator):
         self.Q = Q
         self.partial = partial
         self.alpha = alpha
-        self.b = b if b is not None else 0
+        self.b = b if b is not None else 0.0
 
     def __call__(self, x: NDArray) -> bool | float | int:
         y = self.Q.matvec(x)

--- a/pyproximal/proximal/Quadratic.py
+++ b/pyproximal/proximal/Quadratic.py
@@ -108,7 +108,7 @@ class Quadratic(ProxOperator):
                 Op1 = MatrixMult(np.eye(self.Op.shape[0]) + tau * self.Op.A)
                 x = Op1.div(y)
             else:
-                Op1 = Identity(self.Op.shape[0], dtype=self.Op.dtype) + tau * self.Op.A
+                Op1 = Identity(self.Op.shape[0], dtype=self.Op.dtype) + tau * self.Op
                 x = lsqr(Op1, y, iter_lim=self.niter, x0=self.x0)[0]
             if self.warm:
                 self.x0 = x
@@ -131,9 +131,9 @@ class Quadratic(ProxOperator):
 
         """
         if self.Op is not None and self.b is not None:
-            g = self.Op.matvec(x) / 2.0 + x
+            g = self.Op.matvec(x) + self.b
         elif self.b is not None:
-            g = x
+            g = self.b
         else:
             g = 0.0
         return g

--- a/pyproximal/proximal/RelaxedMS.py
+++ b/pyproximal/proximal/RelaxedMS.py
@@ -32,16 +32,6 @@ def _l2(x: NDArray, alpha: float) -> NDArray:
     return y
 
 
-def _current_kappa(
-    kappa: FloatCallableLike,
-    count: int,
-) -> float | NDArray:
-    if not callable(kappa):
-        return kappa
-    else:
-        return kappa(count)
-
-
 class RelaxedMumfordShah(ProxOperator):
     r"""Relaxed Mumford-Shah norm proximal operator.
 

--- a/pyproximal/proximal/Simplex.py
+++ b/pyproximal/proximal/Simplex.py
@@ -68,7 +68,7 @@ class _Simplex(ProxOperator):
             carr = np.empty(self.dims[self.otheraxis], dtype=np.bool)
             for i in range(self.dims[self.otheraxis]):
                 carr[i] = not (
-                    np.abs(np.sum(x)) - self.radius < tol or np.any(x[i] < 0)
+                    np.abs(np.sum(x[i])) - self.radius > tol or np.any(x[i] < 0)
                 )
             c = bool(np.all(carr))
         return c

--- a/pyproximal/proximal/TV.py
+++ b/pyproximal/proximal/TV.py
@@ -18,7 +18,7 @@ class TV(ProxOperator):
 
     Parameters
     ----------
-    dims : :obj:`tuple`
+    dims : :obj:`tuple`, optional
         Number of samples for each dimension
         (``None`` if only one dimension is available)
     sigma : :obj:`float`, optional
@@ -41,7 +41,7 @@ class TV(ProxOperator):
 
     def __init__(
         self,
-        dims: ShapeLike,
+        dims: ShapeLike | None,
         sigma: float = 1.0,
         niter: int | Callable[[int], int] = 10,
         rtol: float = 1e-4,
@@ -49,7 +49,7 @@ class TV(ProxOperator):
     ) -> None:
         super().__init__(None, True)
         self.dims = dims
-        self.ndim = len(dims)
+        self.ndim = 1 if dims is None else len(dims)
         self.sigma = sigma
         self.niter = niter
         self.count = 0
@@ -185,10 +185,6 @@ class TV(ProxOperator):
         iter = 0
         while iter <= niter:
             # Current Solution
-            if self.ndim == 0:
-                msg = "Need to input at least one value"
-                raise ValueError(msg)
-
             if self.ndim >= 1:
                 div = np.concatenate(
                     (

--- a/pyproximal/proximal/TV.py
+++ b/pyproximal/proximal/TV.py
@@ -48,7 +48,7 @@ class TV(ProxOperator):
         **kwargs: Any,
     ) -> None:
         super().__init__(None, True)
-        self.dims = dims
+        self.dims = (0,) if dims is None else dims
         self.ndim = 1 if dims is None else len(dims)
         self.sigma = sigma
         self.niter = niter

--- a/pyproximal/utils/gradtest.py
+++ b/pyproximal/utils/gradtest.py
@@ -220,6 +220,8 @@ def gradtest_bilinear(
         r_or_i = np.random.randint(0, 2)
         if r_or_i == 1:
             delta1 = delta * 1j
+    else:
+        r_or_i = 0
 
     # extract gradient value to test
     if x_or_y == 0:

--- a/pytests/test_basic.py
+++ b/pytests/test_basic.py
@@ -3,6 +3,7 @@ import pytest
 from numpy.testing import assert_array_equal
 from pylops import MatrixMult
 
+from pyproximal import ProxOperator
 from pyproximal.proximal import L1, L2, Euclidean, Quadratic
 
 par1 = {"ny": 21, "nx": 11, "nt": 20, "imag": 0, "dtype": "float32"}  # real
@@ -12,25 +13,42 @@ np.random.seed(10)
 
 
 @pytest.mark.parametrize("par", [par1])
+def test_ProxOperator(par):
+    """Check errors are raised for non-implemented methods"""
+    pop = ProxOperator()
+
+    with pytest.raises(
+        NotImplementedError, match="This ProxOperator's __call__ method"
+    ):
+        pop(np.ones(4))
+
+
+@pytest.mark.parametrize("par", [par1])
 def test_negativetau(par):
     """Check error is raised when passing negative tau"""
     l1 = Euclidean(sigma=1.0)
     x = np.arange(-5, 5, 0.1)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="tau must be positive"):
         l1.prox(x, -1)
 
 
 @pytest.mark.parametrize("par", [par1])
-def test_add(par):
-    """Check __add__ operator against one proximal operator to which we
-    can add a dot-product (e.g., Quadratic)
+@pytest.mark.parametrize("sign", [-1, 1])
+def test_add_sub(par, sign):
+    """Check __add__ and  __sub__ operators against one proximal
+    operator to which we can add a dot-product (e.g., Quadratic)
     """
+    np.random.seed(10)
+
     A = np.random.normal(0, 1, (par["nx"], par["nx"]))
     A = A.T @ A
-    quad = Quadratic(Op=MatrixMult(A), b=np.ones(par["nx"]), niter=500)
+    quad = Quadratic(Op=MatrixMult(A), b=sign * np.ones(par["nx"]), niter=500)
     quad1 = Quadratic(Op=MatrixMult(A), niter=500)
-    quad1 = quad1 + np.ones(par["nx"])
+    if sign == 1:
+        quad1 = quad1 + np.ones(par["nx"])
+    else:
+        quad1 = quad1 - np.ones(par["nx"])
 
     # prox / dualprox
     x = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
@@ -44,6 +62,8 @@ def test_mul(par):
     """Check __mul__ operator against one proximal operator to which we
     can multiply a scalar (e.g., L2)
     """
+    np.random.seed(10)
+
     sigma = 2.0
     l2 = L2(sigma=sigma)
     l21 = sigma * L2()
@@ -56,13 +76,43 @@ def test_mul(par):
 
 
 @pytest.mark.parametrize("par", [par1])
-def test_precomposition_type(par):
-    """Check precomposition method raises an error
+def test_adjoint(par):
+    """Check _adjoint operator against one proximal operator
+    that implements proxdual
+    """
+    np.random.seed(10)
+
+    sigma = 2.0
+    l1 = L1(sigma=sigma)
+    l1H = l1.H
+
+    # prox / dualprox
+    x = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
+    tau = 2.0
+    assert_array_equal(l1.proxdual(x, tau), l1H.prox(x, tau))
+    assert_array_equal(l1.prox(x, tau), l1H.proxdual(x, tau))
+
+
+@pytest.mark.parametrize("par", [par1])
+def test_precomposition(par):
+    """Check precomposition method and that it raises an error
     when type of a and b is incorrect
     """
-    l1 = L1()
+    np.random.seed(10)
 
-    with pytest.raises(NotImplementedError):
+    l1 = L1()
+    a, b = 1.0, 5.0
+    l1prec = l1.precomposition(a=a, b=b)
+    x = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
+
+    # norm
+    assert l1prec(x) == l1prec.f(a * x + b)
+
+    # grad
+    assert_array_equal(l1prec.grad(x), a * l1.grad(a * x + b))
+
+    # check errors
+    with pytest.raises(NotImplementedError, match="a must be of type float and b"):
         _ = l1.precomposition(a=1, b=np.ones(5))  # should be float
 
         _ = l1.precomposition(
@@ -72,13 +122,25 @@ def test_precomposition_type(par):
 
 
 @pytest.mark.parametrize("par", [par1])
-def test_postcomposition_type(par):
-    """Check postcomposition method raises an error
+def test_postcomposition(par):
+    """Check postcomposition method and that it raises an error
     when type of sigma is incorrect
     """
-    l1 = L1()
+    np.random.seed(10)
 
-    with pytest.raises(NotImplementedError):
+    l1 = L1()
+    sigma = 2.0
+    l1post = l1.postcomposition(sigma=sigma)
+    x = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
+
+    # norm
+    assert l1post(x) == sigma * l1(x)
+
+    # grad
+    assert_array_equal(l1post.grad(x), sigma * l1.grad(x))
+
+    # check errors
+    with pytest.raises(NotImplementedError, match="sigma must be of type float"):
         _ = l1.postcomposition(
             sigma=1,  # should be float
         )
@@ -89,12 +151,23 @@ def test_postcomposition_type(par):
 
 @pytest.mark.parametrize("par", [par1])
 def test_affine_addition_type(par):
-    """Check affine_addition method raises an error
+    """Check affine_addition method and that it raises an error
     when type of v is incorrect
     """
     l1 = L1()
 
-    with pytest.raises(NotImplementedError):
+    x = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
+    v = np.ones(par["nx"]).astype(par["dtype"])
+    l1aff = l1 + v
+
+    # norm
+    assert l1aff(x) == l1(x) + np.dot(v, x)
+
+    # grad
+    assert_array_equal(l1aff.grad(x), l1.grad(x) + v)
+
+    # error
+    with pytest.raises(NotImplementedError, match="v must be a numpy.ndarray"):
         _ = l1.affine_addition(
             v=1,  # should be np.ndarray or cp.ndarray
         )

--- a/pytests/test_concave_penalties.py
+++ b/pytests/test_concave_penalties.py
@@ -101,7 +101,9 @@ def test_ETP(par):
 def test_Geman(par):
     """Geman penalty and proximal/dual proximal"""
     np.random.seed(10)
+
     geman = Geman(sigma=par["sigma"], gamma=par["gamma"])
+
     # Geman
     x = np.random.normal(0.0, 10.0, par["nx"]).astype(par["dtype"])
     expected = par["sigma"] * np.linalg.norm(np.abs(x) / (np.abs(x) + par["gamma"]), 1)
@@ -116,7 +118,9 @@ def test_Geman(par):
 def test_QuadraticEnvelopeCard(par):
     """QuadraticEnvelopeCard penalty and proximal/dual proximal"""
     np.random.seed(10)
+
     fmu = QuadraticEnvelopeCard(mu=par["mu"])
+
     # Quadratic envelope of the l0-penalty
     x = np.random.normal(0.0, 10.0, par["nx"]).astype(par["dtype"])
     expected = np.linalg.norm(
@@ -126,4 +130,6 @@ def test_QuadraticEnvelopeCard(par):
 
     # Check proximal operator
     tau = 0.25
+    assert moreau(fmu, x, tau)
+    tau = 1.25
     assert moreau(fmu, x, tau)

--- a/pytests/test_concave_penalties.py
+++ b/pytests/test_concave_penalties.py
@@ -22,6 +22,15 @@ par2 = {
 }  # odd float64
 
 
+def test_SCAD_sigmaneg():
+    """Check SCAD returns an error for negative sigma"""
+    with pytest.raises(ValueError, match='Variable "sigma" must be positive'):
+        _ = SCAD(sigma=-1.0)
+
+    with pytest.raises(ValueError, match='Variable "a" must be larger'):
+        _ = SCAD(sigma=1.0, a=1.7)
+
+
 @pytest.mark.parametrize("par", [(par1), (par2)])
 def test_SCAD(par):
     """SCAD penalty and proximal/dual proximal"""
@@ -37,23 +46,33 @@ def test_SCAD(par):
         (par["a"] + 1) * par["sigma"] ** 2 / 2 * np.count_nonzero(x)
     )
 
-    # Check proximal operator
+    # prox / dualprox
     tau = 2.0
     x = np.random.normal(0.0, 10.0, par["nx"]).astype(par["dtype"])
     assert moreau(scad, x, tau)
 
-    # Make sure that a ValueError is raised if you try to instantiate with a <= 2
-    with pytest.raises(ValueError):
-        _ = SCAD(sigma=1.0, a=1.7)
+
+def test_Log_Log1_neg():
+    """Check Log/Log1 returns an error for negative inputs"""
+    with pytest.raises(ValueError, match='Variable "sigma" must be positive'):
+        _ = Log(sigma=-1.0)
+
+    with pytest.raises(ValueError, match='Variable "gamma" must be positive'):
+        _ = Log(sigma=1.0, gamma=-1.0)
+
+    with pytest.raises(ValueError, match='Variable "delta" must be positive'):
+        _ = Log1(1.0, delta=-1.0)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2)])
 def test_Log(par):
     """Log penalty and proximal/dual proximal"""
     np.random.seed(10)
+
     log = Log(sigma=par["sigma"], gamma=par["gamma"])
-    # Log
     x = np.random.normal(0.0, 10.0, par["nx"]).astype(par["dtype"])
+
+    # norm
     expected = (
         par["sigma"]
         / np.log(par["gamma"] + 1)
@@ -61,7 +80,7 @@ def test_Log(par):
     )
     assert log(x) == pytest.approx(expected)
 
-    # Check proximal operator
+    # prox / dualprox
     tau = 2.0
     assert moreau(log, x, tau)
 
@@ -70,21 +89,37 @@ def test_Log(par):
 def test_Log1(par):
     """Log1 penalty and proximal/dual proximal"""
     np.random.seed(10)
-    log = Log1(sigma=par["sigma"])
 
-    # Check proximal operator
-    tau = 2.0
+    log = Log1(sigma=par["sigma"])
     x = np.random.normal(0.0, 10.0, par["nx"]).astype(par["dtype"])
+
+    # norm
+    expected = float(np.sum(np.log(np.abs(x) + log.delta)))
+    assert log(x) == pytest.approx(expected)
+
+    # prox / dualprox
+    tau = 2.0
     assert moreau(log, x, tau)
+
+
+def test_ETP_sigma_gamma_neg():
+    """Check ETP returns an error for negative sigma and gamma"""
+    with pytest.raises(ValueError, match='Variable "sigma" must be positive'):
+        _ = ETP(sigma=-1.0)
+
+    with pytest.raises(ValueError, match='Variable "gamma" must be strictly'):
+        _ = ETP(sigma=1.0, gamma=0.0)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2)])
 def test_ETP(par):
     """Exponential-type penalty and proximal/dual proximal"""
     np.random.seed(10)
+
     etp = ETP(sigma=par["sigma"], gamma=par["gamma"])
-    # ETP
     x = np.random.normal(0.0, 10.0, par["nx"]).astype(par["dtype"])
+
+    # norm
     expected = (
         par["sigma"]
         / (1 - np.exp(-par["gamma"]))
@@ -92,9 +127,18 @@ def test_ETP(par):
     )
     assert etp(x) == pytest.approx(expected)
 
-    # Check proximal operator
+    # prox / dualprox
     tau = 2.0
     assert moreau(etp, x, tau)
+
+
+def test_Geman_sigma_gamma_neg():
+    """Check Geman returns an error for negative sigma and gamma"""
+    with pytest.raises(ValueError, match='Variable "sigma" must be positive'):
+        _ = Geman(sigma=-1.0)
+
+    with pytest.raises(ValueError, match='Variable "gamma" must be strictly'):
+        _ = Geman(sigma=1.0, gamma=0.0)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2)])
@@ -103,13 +147,13 @@ def test_Geman(par):
     np.random.seed(10)
 
     geman = Geman(sigma=par["sigma"], gamma=par["gamma"])
-
-    # Geman
     x = np.random.normal(0.0, 10.0, par["nx"]).astype(par["dtype"])
+
+    # norm
     expected = par["sigma"] * np.linalg.norm(np.abs(x) / (np.abs(x) + par["gamma"]), 1)
     assert geman(x) == pytest.approx(expected)
 
-    # Check proximal operator
+    # prox / dualprox
     tau = 2.0
     assert moreau(geman, x, tau)
 

--- a/pytests/test_dykstra.py
+++ b/pytests/test_dykstra.py
@@ -28,6 +28,13 @@ par1prox = {"nx": 10, "ny": 10, "sigma": 1.0, "dtype": "float32"}  # even float3
 par2prox = {"nx": 11, "ny": 14, "sigma": 2.0, "dtype": "float64"}  # odd float64
 
 
+def test_GenericIntersectionProx_empty():
+    """Test GenericIntersectionProx raises an error when the list of
+    projections is empty"""
+    with pytest.raises(ValueError, match="items must not be empty"):
+        GenericIntersectionProx([])
+
+
 @pytest.mark.parametrize("par", [(par1proj), (par2proj)])
 def test_GenericIntersectionProx(par: dict[str, Any]) -> None:
     """GenericIntersectionProx and proximal/dual proximal of related indicator"""

--- a/pytests/test_dykstra.py
+++ b/pytests/test_dykstra.py
@@ -108,6 +108,29 @@ def test_GenericIntersectionProx(par: dict[str, Any]) -> None:
 
 
 @pytest.mark.parametrize("par", [(par1prox), (par2prox)])
+def test_Sum_l1(par: dict[str, Any]) -> None:
+    """Check Sum for single L1 operator (edge-case)"""
+
+    atol = 1e-6
+    tau = 1.0
+    rng = np.random.default_rng(10)
+
+    x = rng.normal(0.0, 3.5, par["nx"]).astype(par["dtype"])
+    sigma = rng.uniform(0.1, 1.0)
+
+    l1 = L1(sigma=sigma)
+
+    d = Sum(
+        [
+            l1,
+        ]
+    )
+    assert np.allclose(l1(x), d(x), atol=atol)
+    assert np.allclose(l1.prox(x, tau), d.prox(x, tau), atol=atol)
+    assert moreau(d, x, tau)
+
+
+@pytest.mark.parametrize("par", [(par1prox), (par2prox)])
 def test_Sum_l1_l1(par: dict[str, Any]) -> None:
     """Check Sum for L1 + L1"""
 

--- a/pytests/test_grads.py
+++ b/pytests/test_grads.py
@@ -40,7 +40,7 @@ def test_l2(par):
             complexflag=par["complexflag"],
             raiseerror=True,
             atol=1e-3,
-            verb=False,
+            verb=True,  # to test verbosity
         )
 
     # x - b
@@ -94,5 +94,5 @@ def test_lowrank(par):
             complexflag=par["complexflag"],
             raiseerror=True,
             atol=1e-3,
-            verb=False,
+            verb=True,  # to test verbosity
         )

--- a/pytests/test_norms.py
+++ b/pytests/test_norms.py
@@ -1,7 +1,14 @@
 import numpy as np
 import pytest
 from numpy.testing import assert_array_almost_equal
-from pylops.basicoperators import Diagonal, FirstDerivative, Identity, MatrixMult
+from pylops.basicoperators import (
+    Diagonal,
+    FirstDerivative,
+    Gradient,
+    Identity,
+    MatrixMult,
+)
+from pylops.signalprocessing import Convolve1D
 
 from pyproximal.proximal import (
     L0,
@@ -12,6 +19,7 @@ from pyproximal.proximal import (
     Euclidean,
     Huber,
     HuberCircular,
+    L2Convolve,
     L21_plus_L1,
     Nuclear,
     RelaxedMumfordShah,
@@ -38,25 +46,35 @@ def test_Euclidean(par):
     # grad
     assert_array_almost_equal(eucl.grad(x), par["sigma"] * x / np.linalg.norm(x))
 
-    # prox / dualprox
+    # prox / dualprox (checking also verbosity)
     tau = 2.0
-    assert moreau(eucl, x, tau)
+    assert moreau(eucl, x, tau, verb=True)
+
+
+def test_L2_solver():
+    """Check L2 raises an error if the solver is not recognized"""
+    with pytest.raises(ValueError, match="Available options are:"):
+        d = np.random.normal(0.0, 1.0, 10)
+        _ = L2(Op=Diagonal(d), solver="foo")
 
 
 @pytest.mark.parametrize("par", [(par1), (par2)])
-def test_L2_op(par):
-    """L2 norm of Op*x and proximal (since Op is a Diagonal
-    operator the denominator becomes 1 + sigma*tau*d[i]^2
-    for every i)"""
+@pytest.mark.parametrize("niter", [500, lambda x: 500])
+def test_L2_op(par, niter):
+    """L2 norm of Op*x and grad and proximal"""
     np.random.seed(10)
 
     b = np.zeros(par["nx"], dtype=par["dtype"])
     d = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
-    l2 = L2(Op=Diagonal(d, dtype=par["dtype"]), b=b, sigma=par["sigma"], niter=500)
+    l2 = L2(Op=Diagonal(d, dtype=par["dtype"]), b=b, sigma=par["sigma"], niter=niter)
 
     # norm
     x = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
     assert l2(x) == (par["sigma"] / 2.0) * np.linalg.norm(d * x) ** 2
+
+    # grad: since Op is a Diagonal operator the gradient becomes
+    # -sigma*d[i]*(b[i] - d[i]*x[i]) for every i
+    assert_array_almost_equal(l2.grad(x), -par["sigma"] * d * (b - d * x))
 
     # prox: since Op is a Diagonal operator the denominator becomes
     # 1 + sigma*tau*d[i] for every i
@@ -66,32 +84,44 @@ def test_L2_op(par):
 
 
 @pytest.mark.parametrize("par", [(par1), (par2)])
-def test_L2_op_solver(par):
+@pytest.mark.parametrize("explicit", [False, True])
+def test_L2_op_solver(par, explicit):
     """L2 norm of Op*x-b and proximal, the first compared to close-form
     solution and the second with different choices of solver."""
     np.random.seed(10)
 
-    Op = MatrixMult(
-        np.random.normal(0, 1, (par["nx"], par["nx"])).astype(dtype=par["dtype"]),
-        dtype=par["dtype"],
-    )
-    b = np.ones(par["nx"], dtype=par["dtype"])
-    l2_leg = L2(Op=Op, b=b, sigma=par["sigma"], solver="legacy", niter=par["nx"])
-    l2_cg = L2(Op=Op, b=b, sigma=par["sigma"], solver="cg", niter=par["nx"])
-    l2_cgls = L2(Op=Op, b=b, sigma=par["sigma"], solver="cgls", niter=par["nx"])
+    for q in (None, np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])):
+        Op = MatrixMult(
+            np.random.normal(0, 1, (par["nx"], par["nx"])).astype(dtype=par["dtype"]),
+            dtype=par["dtype"],
+        )
+        Op.explicit = explicit
+        b = np.ones(par["nx"], dtype=par["dtype"])
+        l2_leg = L2(
+            Op=Op, b=b, sigma=par["sigma"], q=q, solver="legacy", niter=2 * par["nx"]
+        )
+        l2_cg = L2(
+            Op=Op, b=b, sigma=par["sigma"], q=q, solver="cg", niter=2 * par["nx"]
+        )
+        l2_cgls = L2(
+            Op=Op, b=b, sigma=par["sigma"], q=q, solver="cgls", niter=2 * par["nx"]
+        )
 
-    # norm
-    x = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
-    assert l2_leg(x) == (par["sigma"] / 2.0) * np.linalg.norm(Op * x - b) ** 2
+        # norm
+        x = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
+        norm = (par["sigma"] / 2.0) * np.linalg.norm(Op * x - b) ** 2
+        if q is not None:
+            norm += np.dot(q, x)
+        assert l2_leg(x) == norm
 
-    # prox
-    tau = 2.0
-    prox_leg = l2_leg.prox(x, tau)
-    prox_cg = l2_cg.prox(x, tau)
-    prox_cgls = l2_cgls.prox(x, tau)
+        # prox
+        tau = 2.0
+        prox_leg = l2_leg.prox(x, tau)
+        prox_cg = l2_cg.prox(x, tau)
+        prox_cgls = l2_cgls.prox(x, tau)
 
-    assert_array_almost_equal(prox_leg, prox_cg, decimal=4)
-    assert_array_almost_equal(prox_leg, prox_cgls, decimal=4)
+        assert_array_almost_equal(prox_leg, prox_cg, decimal=4)
+        assert_array_almost_equal(prox_leg, prox_cgls, decimal=4)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2)])
@@ -144,34 +174,148 @@ def test_L2_diff(par):
 
 @pytest.mark.parametrize("par", [(par1), (par2)])
 def test_L2_x(par):
-    """L2 norm of x and proximal (implemented both directly and
+    """L2 norm of x and grad and proximal (implemented both directly and
     with identity operator and zero b and compared to closed-form
     solution)"""
     np.random.seed(10)
 
-    l2 = L2(
-        Op=Identity(par["nx"], dtype=par["dtype"]),
-        b=np.zeros(par["nx"], dtype=par["dtype"]),
+    for q in (None, np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])):
+        l2 = L2(
+            Op=Identity(par["nx"], dtype=par["dtype"]),
+            b=np.zeros(par["nx"], dtype=par["dtype"]),
+            sigma=par["sigma"],
+            q=q,
+        )
+        l2direct = L2(
+            sigma=par["sigma"],
+            q=q,
+        )
+
+        # norm
+        x = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
+        norm = (par["sigma"] / 2.0) * np.linalg.norm(x) ** 2
+        if q is not None:
+            norm += np.dot(q, x)
+        assert l2(x) == norm
+        assert l2direct(x) == norm
+
+        # grad
+        grad = par["sigma"] * x
+        if q is not None:
+            grad += q
+        assert_array_almost_equal(l2.grad(x), grad)
+
+        # prox
+        tau = 2.0
+        if q is not None:
+            prox = (x - tau * q) / (1.0 + par["sigma"] * tau)
+        else:
+            prox = x / (1.0 + par["sigma"] * tau)
+        assert_array_almost_equal(l2.prox(x, tau), prox)
+        assert_array_almost_equal(l2direct.prox(x, tau), prox)
+
+
+@pytest.mark.parametrize("par", [(par1), (par2)])
+def test_L2Convolve(par):
+    """L2Convolve norm of x and grad and prox/dualprox (norm and grad are compared
+    to solution in the time domain)"""
+    np.random.seed(10)
+
+    # 1d
+    h = np.ones(3) / 3.0
+    Cop = Convolve1D(par["nx"], h=h, offset=1, dtype=par["dtype"])
+    b = np.zeros(par["nx"], dtype=par["dtype"])
+
+    l2 = L2Convolve(
+        h=h,
+        b=b,
         sigma=par["sigma"],
     )
-    l2direct = L2(
-        sigma=par["sigma"],
-    )
+
+    # define x with a spike in the middle to
+    # avoid boundary effects in the convolution
+    # in the time vs frequency domain
+    x = np.zeros(par["nx"], dtype=par["dtype"])
+    x[par["nx"] // 2] = 1.0
 
     # norm
-    x = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
-    assert l2(x) == (par["sigma"] / 2.0) * np.linalg.norm(x) ** 2
-    assert l2direct(x) == (par["sigma"] / 2.0) * np.linalg.norm(x) ** 2
+    norm = (par["sigma"] / 2.0) * np.linalg.norm(b - Cop @ x) ** 2
+    assert l2(x) == pytest.approx(norm)
 
-    # prox
+    # grad
+    grad = par["sigma"] * Cop.H @ (Cop @ x - b)
+    assert_array_almost_equal(l2.grad(x), grad)
+
+    # prox / dualprox
     tau = 2.0
-    assert_array_almost_equal(l2.prox(x, tau), x / (1.0 + par["sigma"] * tau))
-    assert_array_almost_equal(l2direct.prox(x, tau), x / (1.0 + par["sigma"] * tau))
+    moreau(l2, x, tau)
+
+    # 2d on first
+    h = np.ones(3) / 3.0
+    Cop = Convolve1D((par["nx"], 4), h=h, offset=1, axis=0, dtype=par["dtype"])
+    b = np.zeros((par["nx"], 4), dtype=par["dtype"])
+
+    l2 = L2Convolve(
+        h=h,
+        b=b,
+        sigma=par["sigma"],
+        dims=(par["nx"], 4),
+        dir=0,
+    )
+
+    # define x with a spike in the middle to
+    # avoid boundary effects in the convolution
+    # in the time vs frequency domain
+    x = np.zeros((par["nx"], 4), dtype=par["dtype"])
+    x[par["nx"] // 2] = 1.0
+
+    # norm
+    norm = (par["sigma"] / 2.0) * np.linalg.norm(b - Cop @ x) ** 2
+    assert l2(x) == pytest.approx(norm)
+
+    # grad
+    grad = par["sigma"] * Cop.H @ (Cop @ x - b)
+    assert_array_almost_equal(l2.grad(x).reshape(par["nx"], 4), grad)
+
+    # prox / dualprox
+    tau = 2.0
+    moreau(l2, x.ravel(), tau)
+
+    # 2d on last
+    h = np.ones(3) / 3.0
+    Cop = Convolve1D((4, par["nx"]), h=h, offset=1, axis=-1, dtype=par["dtype"])
+    b = np.zeros((4, par["nx"]), dtype=par["dtype"])
+
+    l2 = L2Convolve(
+        h=h,
+        b=b,
+        sigma=par["sigma"],
+        dims=(4, par["nx"]),
+        dir=-1,
+    )
+
+    # define x with a spike in the middle to
+    # avoid boundary effects in the convolution
+    # in the time vs frequency domain
+    x = np.zeros((4, par["nx"]), dtype=par["dtype"])
+    x[:, par["nx"] // 2] = 1.0
+
+    # norm
+    norm = (par["sigma"] / 2.0) * np.linalg.norm(b - Cop @ x) ** 2
+    assert l2(x) == pytest.approx(norm)
+
+    # grad
+    grad = par["sigma"] * Cop.H @ (Cop @ x - b)
+    assert_array_almost_equal(l2.grad(x).reshape(4, par["nx"]), grad)
+
+    # prox / dualprox
+    tau = 2.0
+    moreau(l2, x.ravel(), tau)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2)])
 def test_L1(par):
-    """L1 norm and proximal/dual proximal"""
+    """L1 norm and grad and proximal/dual proximal"""
     np.random.seed(10)
 
     l1 = L1(sigma=par["sigma"])
@@ -179,6 +323,11 @@ def test_L1(par):
     # norm
     x = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
     assert l1(x) == par["sigma"] * np.sum(np.abs(x))
+
+    # grad (note that since this norm is non-smooth, the
+    # gradient method is not implemented; as such the gradient
+    # of the Moreau envelope is called instead
+    _ = l1.grad(x)
 
     # prox / dualprox
     tau = 2.0
@@ -316,27 +465,51 @@ def test_HuberCircular(par):
 
 @pytest.mark.parametrize("par", [(par1), (par2)])
 def test_TV(par):
-    """TV norm of x and proximal"""
+    """TV norm of x and proximal/dual proximal"""
     np.random.seed(10)
 
+    # 1d
     tv = TV(dims=(par["nx"],), sigma=par["sigma"])
+    x = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
 
     # norm
-    x = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
     derivOp = FirstDerivative(par["nx"], dtype=par["dtype"], kind="forward")
     dx = derivOp @ x
     assert_array_almost_equal(tv(x), par["sigma"] * np.sum(np.abs(dx), axis=0))
 
+    # prox / dualprox
+    tau = 2.0
+    assert moreau(tv, x, tau)
+
+    # 2d/3d/4d
+    dims = ((4, par["nx"]), (4, 8, par["nx"]), (4, 4, 8, par["nx"]))
+
+    for dim in dims:
+        tv = TV(dims=dim, sigma=par["sigma"])
+        x = np.random.normal(0.0, 1.0, dim).astype(par["dtype"])
+
+        # norm
+        derivOp = Gradient(dim, dtype=par["dtype"], kind="forward")
+        dx = derivOp @ x
+        f = 0.0
+        for g in dx:
+            f += np.power(abs(g), 2)
+        assert_array_almost_equal(tv(x), par["sigma"] * np.sum(np.sqrt(f)))
+
+        # prox / dualprox
+        tau = 2.0
+        assert moreau(tv, x.ravel(), tau)
+
 
 @pytest.mark.parametrize("par", [(par1), (par2)])
-def test_rMS(par):
+@pytest.mark.parametrize("kappa", [1.0, lambda x: 1.0])
+def test_rMS(par, kappa):
     """rMS norm and proximal/dual proximal"""
-    kappa = 1.0
     rMS = RelaxedMumfordShah(sigma=par["sigma"], kappa=kappa)
 
     # norm
     x = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
-    assert rMS(x) == np.minimum(par["sigma"] * np.linalg.norm(x) ** 2, kappa)
+    assert rMS(x) == np.minimum(par["sigma"] * np.linalg.norm(x) ** 2, 1.0)
 
     # prox / dualprox
     tau = 2.0

--- a/pytests/test_norms.py
+++ b/pytests/test_norms.py
@@ -27,6 +27,8 @@ np.random.seed(10)
 @pytest.mark.parametrize("par", [(par1), (par2)])
 def test_Euclidean(par):
     """Euclidean norm and proximal/dual proximal"""
+    np.random.seed(10)
+
     eucl = Euclidean(sigma=par["sigma"])
 
     # norm
@@ -46,6 +48,8 @@ def test_L2_op(par):
     """L2 norm of Op*x and proximal (since Op is a Diagonal
     operator the denominator becomes 1 + sigma*tau*d[i]^2
     for every i)"""
+    np.random.seed(10)
+
     b = np.zeros(par["nx"], dtype=par["dtype"])
     d = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
     l2 = L2(Op=Diagonal(d, dtype=par["dtype"]), b=b, sigma=par["sigma"], niter=500)
@@ -65,6 +69,8 @@ def test_L2_op(par):
 def test_L2_op_solver(par):
     """L2 norm of Op*x-b and proximal, the first compared to close-form
     solution and the second with different choices of solver."""
+    np.random.seed(10)
+
     Op = MatrixMult(
         np.random.normal(0, 1, (par["nx"], par["nx"])).astype(dtype=par["dtype"]),
         dtype=par["dtype"],
@@ -94,6 +100,8 @@ def test_L2_dense(par):
     compared to closed-form solution (since Op is a Diagonal
     operator the denominator becomes 1 + sigma*tau*d[i]^2 for
     every i)"""
+    np.random.seed(10)
+
     for densesolver in ("numpy", "scipy", "factorize"):
         b = np.zeros(par["nx"], dtype=par["dtype"])
         d = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
@@ -118,6 +126,8 @@ def test_L2_dense(par):
 def test_L2_diff(par):
     """L2 norm of difference (x-b) and proximal
     compared to closed-form solution"""
+    np.random.seed(10)
+
     b = np.ones(par["nx"], dtype=par["dtype"])
     l2 = L2(b=b, sigma=par["sigma"])
 
@@ -137,6 +147,8 @@ def test_L2_x(par):
     """L2 norm of x and proximal (implemented both directly and
     with identity operator and zero b and compared to closed-form
     solution)"""
+    np.random.seed(10)
+
     l2 = L2(
         Op=Identity(par["nx"], dtype=par["dtype"]),
         b=np.zeros(par["nx"], dtype=par["dtype"]),
@@ -160,7 +172,25 @@ def test_L2_x(par):
 @pytest.mark.parametrize("par", [(par1), (par2)])
 def test_L1(par):
     """L1 norm and proximal/dual proximal"""
+    np.random.seed(10)
+
     l1 = L1(sigma=par["sigma"])
+
+    # norm
+    x = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
+    assert l1(x) == par["sigma"] * np.sum(np.abs(x))
+
+    # prox / dualprox
+    tau = 2.0
+    assert moreau(l1, x, tau)
+
+
+@pytest.mark.parametrize("par", [(par1), (par2)])
+def test_L1_func(par):
+    """L1 norm and proximal/dual proximal with sigma as callable"""
+    np.random.seed(10)
+
+    l1 = L1(sigma=lambda x: par["sigma"])
 
     # norm
     x = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
@@ -174,6 +204,8 @@ def test_L1(par):
 @pytest.mark.parametrize("par", [(par1), (par2)])
 def test_L1_diff(par):
     """L1 norm of difference and proximal/dual proximal"""
+    np.random.seed(10)
+
     g = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
     l1 = L1(sigma=par["sigma"], g=g)
 
@@ -189,6 +221,8 @@ def test_L1_diff(par):
 @pytest.mark.parametrize("par", [(par1), (par2)])
 def test_L0(par):
     """L0 norm and proximal/dual proximal"""
+    np.random.seed(10)
+
     l0 = L0(sigma=par["sigma"])
 
     # norm
@@ -205,6 +239,8 @@ def test_L21(par):
     """L21 norm and proximal/dual proximal on 2d array (compare it with N
     L2 norms on the columns of the 2d array
     """
+    np.random.seed(10)
+
     l21 = L21(ndim=2, sigma=par["sigma"])
 
     # norm
@@ -220,6 +256,8 @@ def test_L21(par):
 @pytest.mark.parametrize("par", [(par1), (par2)])
 def test_L21_plus_L1(par):
     """L21 plus L1 norm on 2darray."""
+    np.random.seed(10)
+
     l21_plus_l1 = L21_plus_L1(sigma=par["sigma"], rho=0.8)
 
     # norm
@@ -239,6 +277,8 @@ def test_L21_plus_L1(par):
 @pytest.mark.parametrize("par", [(par1), (par2)])
 def test_Huber(par):
     """Huber norm and proximal/dual proximal"""
+    np.random.seed(10)
+
     hub = Huber(alpha=par["sigma"])
 
     # norm
@@ -253,14 +293,21 @@ def test_Huber(par):
 @pytest.mark.parametrize("par", [(par1), (par2)])
 def test_HuberCircular(par):
     """Circular Huber norm and proximal/dual proximal"""
+    np.random.seed(10)
+
     hub = HuberCircular(alpha=par["sigma"])
 
     # norm
     x = np.random.uniform(0.0, 0.1, par["nx"]).astype(par["dtype"])
-    x = (
+    x_below = (
         (0.1 * par["sigma"]) * x / np.linalg.norm(x)
     )  # to ensure that is smaller than sigma
-    assert hub(x) == np.linalg.norm(x) ** 2 / (2 * par["sigma"])
+    assert hub(x_below) == np.linalg.norm(x_below) ** 2 / (2 * par["sigma"])
+
+    x_above = (
+        (2.0 * par["sigma"]) * x / np.linalg.norm(x)
+    )  # to ensure that is larger than sigma
+    assert hub(x_above) == np.linalg.norm(x_above) - 0.5 * par["sigma"]
 
     # prox / dualprox
     tau = 2.0
@@ -270,7 +317,10 @@ def test_HuberCircular(par):
 @pytest.mark.parametrize("par", [(par1), (par2)])
 def test_TV(par):
     """TV norm of x and proximal"""
+    np.random.seed(10)
+
     tv = TV(dims=(par["nx"],), sigma=par["sigma"])
+
     # norm
     x = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
     derivOp = FirstDerivative(par["nx"], dtype=par["dtype"], kind="forward")
@@ -304,6 +354,8 @@ def test_Nuclear_FOM():
 @pytest.mark.parametrize("par", [(par1), (par2)])
 def test_Nuclear(par):
     """Nuclear norm and proximal/dual proximal"""
+    np.random.seed(10)
+
     nucl = Nuclear((par["nx"], 2 * par["nx"]), sigma=par["sigma"])
 
     # norm, cross-check with svd (use tolerance as two methods don't provide
@@ -320,6 +372,8 @@ def test_Nuclear(par):
 @pytest.mark.parametrize("par", [(par1), (par2)])
 def test_Weighted_Nuclear(par):
     """Weighted nuclear norm and proximal/dual proximal"""
+    np.random.seed(10)
+
     weights = par["sigma"] * np.linspace(0.1, 5, 2 * par["nx"])
     nucl = Nuclear((par["nx"], 2 * par["nx"]), sigma=weights)
 

--- a/pytests/test_projection.py
+++ b/pytests/test_projection.py
@@ -83,11 +83,49 @@ def test_L0Ball(par):
 
 
 @pytest.mark.parametrize("par", [(par1), (par2)])
+def test_L0Ball_func(par):
+    """L0 Ball projection and proximal/dual proximal of related indicator
+    with sigma as callable"""
+    np.random.seed(10)
+
+    l0 = L0Ball(lambda x: 1)
+    x = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"]) + 1.0
+
+    # evaluation
+    assert l0(x) is False
+    xp = l0.prox(x, 1.0)
+    assert l0(xp) is True
+
+    # prox / dualprox
+    tau = 2.0
+    assert moreau(l0, x, tau)
+
+
+@pytest.mark.parametrize("par", [(par1), (par2)])
 def test_L10Ball(par):
     """L10 Ball projection and proximal/dual proximal of related indicator"""
     np.random.seed(10)
 
     l0 = L10Ball(3, 1)
+    x = np.random.normal(0.0, 1.0, (3, par["nx"])).astype(par["dtype"]).ravel() + 1.0
+
+    # evaluation
+    assert l0(x) is False
+    xp = l0.prox(x, 1.0)
+    assert l0(xp) is True
+
+    # prox / dualprox
+    tau = 2.0
+    assert moreau(l0, x, tau)
+
+
+@pytest.mark.parametrize("par", [(par1), (par2)])
+def test_L10Ball_func(par):
+    """L10 Ball projection and proximal/dual proximal of related indicator
+    with sigma as callable"""
+    np.random.seed(10)
+
+    l0 = L10Ball(3, lambda x: 1)
     x = np.random.normal(0.0, 1.0, (3, par["nx"])).astype(par["dtype"]).ravel() + 1.0
 
     # evaluation

--- a/pytests/test_projection.py
+++ b/pytests/test_projection.py
@@ -9,6 +9,7 @@ from pyproximal.proximal import (
     EuclideanBall,
     HalfSpace,
     Hankel,
+    Intersection,
     L0Ball,
     L1Ball,
     L10Ball,
@@ -197,6 +198,16 @@ def test_Simplex(par):
         assert moreau(sim1, x, tau)
 
 
+def test_Simplex_engine():
+    """Simplex engine check"""
+    with pytest.raises(KeyError, match="engine must be numpy or "):
+        _ = Simplex(
+            n=10,
+            radius=1.0,
+            engine="foo",
+        )
+
+
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4)])
 def test_Simplex_multi(par):
     """Simplex projection and proximal/dual proximal for 2d array"""
@@ -207,21 +218,34 @@ def test_Simplex_multi(par):
     for engine in ["numpy", "numba"]:
         x = np.abs(np.random.normal(0.0, 1.0, dims).astype(par["dtype"]))
 
+        radius = np.sum(x, axis=par["axis"]).max()
         sim = Simplex(
             n=par["ny"] * par["nx"],
-            radius=5.0,
+            radius=radius,
+            dims=dims,
+            axis=par["axis"],
+            maxiter=50,
+            engine=engine,
+        )
+        sim1 = Simplex(
+            n=par["ny"] * par["nx"],
+            radius=radius - 0.1,
             dims=dims,
             axis=par["axis"],
             maxiter=50,
             engine=engine,
         )
 
+        # evaluation
+        assert sim(x) is True
+        assert sim1(x) is False
+
         # prox
         tau = 2.0
         y = sim.prox(x.ravel(), tau)
         assert_array_almost_equal(
             np.sum(y.reshape(dims), axis=par["axis"]),
-            5.0 * np.ones(dims[otheraxis]),
+            radius * np.ones(dims[otheraxis]),
             decimal=1,
         )
 
@@ -235,12 +259,16 @@ def test_Affine(par):
     np.random.seed(10)
 
     Op = Identity(par["nx"])
-    b = np.random.normal(0.0, 1.0, par["nx"])
+    x = np.ones(par["nx"])
+    b = Op @ x
     aff = AffineSet(Op, b, 10)
+
+    # norm
+    assert aff(x) is True
+    assert aff(x + 1.0) is False
 
     # prox
     tau = 2.0
-    x = np.ones(par["nx"])
     assert_array_almost_equal(aff.prox(x, tau), b)
 
     # prox / dualprox
@@ -271,11 +299,36 @@ def test_HalfSpace(par):
     np.random.seed(10)
 
     w = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
-    b = np.random.normal(0.0, 1.0)
+    x = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
+    b = np.dot(w, x) + 1.0  # to ensure x is inside the half-space
 
     half_space = HalfSpace(w, b)
-    x = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
+
+    # call
+    assert half_space(x) is True
 
     # prox / dualprox
     tau = 2.0
     assert moreau(half_space, x, tau)
+
+
+@pytest.mark.parametrize("par", [(par1), (par2)])
+def test_Intersection(par):
+    """Intersection projection and proximal/dual proximal of related indicator"""
+    np.random.seed(10)
+
+    k = 3
+    x = np.random.normal(0, k, par["nx"])
+    sigma = np.array([[3, 2, 1], [2, 2, 1], [3, 4, 1]])
+    sigma = sigma.T @ sigma
+
+    ic = Intersection(k, par["nx"], sigma, niter=10, tol=1e-3)
+    x = np.random.normal(0.0, 1.0, k * par["nx"]).astype(par["dtype"])
+
+    # call
+    xproj = ic.prox(x, 2.0)
+    assert ic(xproj) is True
+
+    # prox / dualprox
+    tau = 2.0
+    assert moreau(ic, x, tau)

--- a/pytests/test_proximal.py
+++ b/pytests/test_proximal.py
@@ -21,29 +21,57 @@ par1 = {"nx": 10, "ny": 10, "sigma": 1.0, "dtype": "float32"}  # even float32
 par2 = {"nx": 11, "ny": 14, "sigma": 2.0, "dtype": "float64"}  # odd float64
 
 
+def test_Quadratic_nonsquare():
+    """Check Quadratic returns an error if the operator is not square"""
+    np.random.seed(10)
+    A = np.random.normal(0, 1, (10, 11))
+
+    with pytest.raises(ValueError, match="Op must be square"):
+        _ = Quadratic(Op=MatrixMult(A))
+
+
 @pytest.mark.parametrize("par", [(par1), (par2)])
 def test_Quadratic(par):
     """Quadratic functional and proximal/dual proximal"""
     np.random.seed(10)
-    A = np.random.normal(0, 1, (par["nx"], par["nx"]))
+    A = np.random.normal(0, 1, (par["nx"], par["nx"])).astype(par["dtype"])
     A = A.T @ A
-    quad = Quadratic(Op=MatrixMult(A), b=np.ones(par["nx"]), niter=500)
+    b = np.ones(par["nx"]).astype(par["dtype"])
 
-    # prox / dualprox
-    tau = 2.0
-    x = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
-    assert moreau(quad, x, tau)
+    for explicit in [False, True]:
+        Op = MatrixMult(A)
+        Op.explicit = explicit
+        quad = Quadratic(Op=Op, b=b, niter=500)
+        x = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
+
+        # call
+        _ = quad(x)
+
+        # grad
+        grad = A @ x + b
+        assert_array_almost_equal(quad.grad(x), grad, decimal=4)
+
+        # prox / dualprox
+        tau = 2.0
+        assert moreau(quad, x, tau)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2)])
 def test_DotProduct(par):
     """Dot product functional and proximal/dual proximal"""
     np.random.seed(10)
-    quad = Quadratic(b=np.ones(par["nx"]))
+    b = np.ones(par["nx"]).astype(par["dtype"])
+    quad = Quadratic(b=b)
+    x = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
+
+    # call
+    _ = quad(x)
+
+    # grad
+    assert_array_almost_equal(quad.grad(x), b, decimal=4)
 
     # prox / dualprox
     tau = 2.0
-    x = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
     assert moreau(quad, x, tau)
 
 
@@ -52,10 +80,16 @@ def test_Constant(par):
     """Constant functional and proximal/dual proximal"""
     np.random.seed(10)
     quad = Quadratic(c=5.0)
+    x = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
+
+    # call
+    _ = quad(x)
+
+    # grad
+    assert_array_almost_equal(quad.grad(x), 0.0, decimal=4)
 
     # prox / dualprox
     tau = 2.0
-    x = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
     assert moreau(quad, x, tau)
 
 
@@ -186,6 +220,24 @@ def test_SingularValuePenalty(par):
     assert moreau(penalty, X.ravel(), tau)
 
 
+def test_QuadraticEnvelopeCardIndicator():
+    """QuadraticEnvelopeCardIndicator penalty for various edge cases"""
+    fr0 = QuadraticEnvelopeCardIndicator(5)
+
+    # Check value for input size smaller than threshold
+    assert fr0(np.ones(2)) == 0
+
+    # Prox input size smaller than threshold
+    tau = 0.1
+    x = np.ones(2)
+    assert_array_equal(fr0.prox(x, tau), x)
+
+    # Prox for tau larger than 1.0 (hard-thresholding on tau)
+    tau = 2.0
+    x = np.full(2, 5.0)
+    assert_array_equal(fr0.prox(x, tau), x)
+
+
 @pytest.mark.parametrize(
     "par,expected", [(par1, 94.89988856174841), (par2, 145.6421905545182)]
 )
@@ -193,6 +245,7 @@ def test_QuadraticEnvelopeCardIndicator_case01(par, expected):
     """QuadraticEnvelopeCardIndicator penalty and proximal/dual proximal"""
     np.random.seed(10)
     fr0 = QuadraticEnvelopeCardIndicator(4)
+
     # Quadratic envelope of the indicator function of the l0-penalty
     x = np.random.normal(0.0, 10.0, par["nx"]).astype(par["dtype"])
 
@@ -207,6 +260,7 @@ def test_QuadraticEnvelopeCardIndicator_case01(par, expected):
 def test_QuadraticEnvelopeCardIndicator_case02():
     """QuadraticEnvelopeCardIndicator penalty and proximal/dual proximal"""
     fr0 = QuadraticEnvelopeCardIndicator(5)
+
     # Quadratic envelope of the indicator function of the l0-penalty
     x = np.array([1, 1.5, 1.3, 4.1, 2.1, 1.6, 1.8, 1.8])
 

--- a/pytests/test_proximal.py
+++ b/pytests/test_proximal.py
@@ -98,13 +98,16 @@ def test_SemiOrthogonal(par):
     """L1 functional with Semi-Orthogonal operator and proximal/dual proximal"""
     np.random.seed(10)
     l1 = L1()
-    orth = Orthogonal(
-        l1, 2 * Identity(par["nx"]), b=np.arange(par["nx"]), partial=True, alpha=4.0
-    )
+    Op = 2 * Identity(par["nx"])
+    b = np.arange(par["nx"])
+    orth = Orthogonal(l1, Op, b=b, partial=True, alpha=4.0)
+
+    # norm
+    x = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
+    assert orth(x) == pytest.approx(l1(Op @ x + b))
 
     # prox / dualprox
     tau = 2.0
-    x = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
     assert moreau(orth, x, tau)
 
 
@@ -113,25 +116,48 @@ def test_Orthogonal(par):
     """L1 functional with Orthogonal operator and proximal/dual proximal"""
     np.random.seed(10)
     l1 = L1()
-    orth = Orthogonal(l1, Identity(par["nx"]), b=np.arange(par["nx"]))
+    Op = Identity(par["nx"], inplace=False)
+    b = np.arange(par["nx"])
+    orth = Orthogonal(l1, Op, b=b)
+
+    # norm
+    x = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
+    assert orth(x) == pytest.approx(l1(Op @ x + b))
 
     # prox / dualprox
     tau = 2.0
-    x = np.random.normal(0.0, 1.0, par["nx"]).astype(par["dtype"])
     assert moreau(orth, x, tau)
 
 
+def test_VStack_nodim():
+    """VStack operator raises error when neiter restr not dim are provided"""
+    with pytest.raises(ValueError, match="Provide either nn or restr"):
+        _ = VStack(
+            [
+                L2(),
+            ],
+            None,
+            None,
+        )
+
+
 @pytest.mark.parametrize("par", [(par1), (par2)])
-def test_VStack_error(par):
-    """VStack operator error when input has wrong dimensions"""
+def test_VStack_wrongdim(par):
+    """VStack call/prox/grad raise error when input has wrong dimensions"""
     np.random.seed(10)
     nxs = [par["nx"] // 4] * 4
     nxs[-1] = par["nx"] - np.sum(nxs[:-1])
     l2 = L2()
     vstack = VStack([l2] * 4, nxs)
 
-    with pytest.raises(ValueError):
-        vstack.prox(np.ones(nxs[0]), 2)
+    with pytest.raises(ValueError, match="x must have size"):
+        vstack(np.ones(nxs[0]))
+
+    with pytest.raises(ValueError, match="x must have size"):
+        vstack.prox(np.ones(nxs[0]), 2.0)
+
+    with pytest.raises(ValueError, match="x must have size"):
+        vstack.grad(np.ones(nxs[0]))
 
 
 @pytest.mark.parametrize("par", [(par1), (par2)])
@@ -194,12 +220,41 @@ def test_VStack_restriction(par):
 
 
 def test_Nonlinear():
-    """Nonlinear proximal operator. Since this is a template class simply check
-    that errors are raised when not used properly
-    """
+    """Nonlinear proximal operator."""
     np.random.seed(10)
-    with pytest.raises(TypeError):
+
+    # Check error if methods are not implemented
+    with pytest.raises(TypeError, match="Can't instantiate abstract"):
         _ = Nonlinear(np.ones(10))
+
+    # Implement basic nonlinear function and test methods
+    class Sin(Nonlinear):
+        def fun(self, x):
+            return 1 - np.sin(np.pi * x)
+
+        def grad(self, x):
+            return -np.pi * np.cos(np.pi * x)
+
+        def optimize(self):
+            x = self.x0.copy()
+            for _ in range(self.niter):
+                _ = self._fungradprox(x, self.tau)  # just to test the method
+                dx = self._gradprox(x, self.tau)
+                x -= self.alpha * dx
+            return x
+
+    sin = Sin(x0=np.full(1, 0.2), niter=100)
+    sin.alpha = 1e-1
+
+    # call
+    assert sin(0.5) == 0.0
+    assert sin(0.0) == 1.0
+
+    # call and grad
+    assert sin.fungrad(0.5)[1] == pytest.approx(0.0)
+
+    # prox
+    assert sin.prox(np.full(1, 0.5), 1e5)[0] == pytest.approx(0.5)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2)])

--- a/pytests/test_solver.py
+++ b/pytests/test_solver.py
@@ -26,7 +26,7 @@ def test_HQS_noinitial():
     """Check that an error is raised if no initial value
     is provided to HQS solver
     """
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Both x0 or "):
         _ = HQS(
             proxf=L2(),
             proxg=L1(),
@@ -40,7 +40,7 @@ def test_ADMM_noinitial():
     """Check that an error is raised if no initial value
     is provided to ADMM solver
     """
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Both x0 or"):
         _ = ADMM(
             proxf=L2(),
             proxg=L1(),
@@ -54,7 +54,7 @@ def test_ADMML2_noinitial():
     """Check that an error is raised if no initial value
     is provided to PrimalDual solver
     """
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Both x0 or"):
         # Both None
         _ = ADMML2(
             proxg=L1(),
@@ -65,7 +65,7 @@ def test_ADMML2_noinitial():
             x0=None,
             z0=None,
         )
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="x0 must be provided when"):
         # x0 is None (and Op provided)
         _ = ADMML2(
             proxg=L1(),
@@ -82,7 +82,7 @@ def test_LinearizedADMM_noinitial():
     """Check that an error is raised if no initial x0
     is provided to LinearizedADMM solver
     """
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Both x0 or "):
         # Both None
         _ = LinearizedADMM(
             proxf=L2(),
@@ -93,7 +93,7 @@ def test_LinearizedADMM_noinitial():
             x0=None,
             z0=None,
         )
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="x0 must be provided when"):
         # x0 is None (and Op provided)
         _ = LinearizedADMM(
             proxf=L2(),
@@ -109,7 +109,7 @@ def test_LinearizedADMM_noinitial():
 @pytest.mark.parametrize("par", [(par1), (par2)])
 def test_GPG_weights(par):
     """Check GPG raises error if weight is not summing to 1"""
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="must be an array of size"):
         np.random.seed(0)
         n, m = par["n"], par["m"]
 


### PR DESCRIPTION
This PR aims to increase test coverage, mostly by adding tests to `__call__` methods.

It also fixes a number of bugs that were discovered when adding new tests:
- 2 bugs in `Quadratic`
- bug in `L2Convolve` for 2d inputs
- bug in `Simplex` for 2d inputs- 