### PR TITLE
bugfix: wrong initialization of ConsensusADMM

### DIFF
--- a/pyproximal/optimization/primal.py
+++ b/pyproximal/optimization/primal.py
@@ -2063,7 +2063,7 @@ def ConsensusADMM(  # pylint: disable=invalid-name
     m = len(proxfs)
     x_bar = x0.copy()
     x_bar_old = x0.copy()
-    y = ncp.zeros((m, x0.size))
+    y = ncp.zeros((m, x0.size), dtype=x0.dtype)
 
     # iterate
     for iiter in range(niter):

--- a/pyproximal/optimization/primal.py
+++ b/pyproximal/optimization/primal.py
@@ -2063,7 +2063,7 @@ def ConsensusADMM(  # pylint: disable=invalid-name
     m = len(proxfs)
     x_bar = x0.copy()
     x_bar_old = x0.copy()
-    y = ncp.zeros_like(x0)
+    y = ncp.zeros((m, x0.shape[0]))
 
     # iterate
     for iiter in range(niter):

--- a/pyproximal/optimization/primal.py
+++ b/pyproximal/optimization/primal.py
@@ -2063,7 +2063,7 @@ def ConsensusADMM(  # pylint: disable=invalid-name
     m = len(proxfs)
     x_bar = x0.copy()
     x_bar_old = x0.copy()
-    y = ncp.zeros((m, x0.shape[0]))
+    y = ncp.zeros((m, x0.size))
 
     # iterate
     for iiter in range(niter):


### PR DESCRIPTION
Fix initialization of $y_1, \ldots, y_m \in R^d$ to have a correct dimension.

The variable `y` should have a dimension of $m \times d$, where `d` is the dimension of `x0`, but it was incorrectly initialized to a dimension of $d$.

Before this change, the test passed incorrectly when $m \le d$ due to the following line;
```python
x = ncp.stack([proxfs[i].prox(x_bar - y[i], tau) for i in range(m)])
# proxfs.shape == m, x_bar.shape == d, y[0],,,y[d-1] are scalar
```
But this will be an error when $m > d$ because out of index.
The test code in `test_solver.py` uses only $m=2$ proxfs with $d=$ `par["m"] == 10`, so I missed this bug.
I found this when I used $m=4$ proxfs and $d=2$ dimension of `x0`.


Notet that, in the second iteration, the dimension of `y` become $m \times d$ as expected because of the following line, so that the test have passed after iterations even with the wrong initialization.
```python
y = y + x - x_bar  # y.shape == d, x.shape == (m, d), x_bar.shape == d  --> y.shape == (m, d)
```

