### PR TITLE
Doc: fixed equation in rMS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ pyproximal.egg-info/
 pyproximal/version.py
 
 # Development #
+.codacy
 .vscode
 .ipynb_checkpoints/
 notebooks

--- a/pyproximal/optimization/primaldual.py
+++ b/pyproximal/optimization/primaldual.py
@@ -64,10 +64,10 @@ def PrimalDual(
         Linear operator of g
     x0 : :obj:`numpy.ndarray`
         Initial vector
-    tau : :obj:`float` or :obj:`np.ndarray`
+    tau : :obj:`float` or :obj:`numpy.ndarray`
         Stepsize of subgradient of :math:`f`. This can be constant
         or function of iterations (in the latter cases provided as np.ndarray)
-    mu : :obj:`float` or :obj:`np.ndarray`
+    mu : :obj:`float` or :obj:`numpy.ndarray`
         Stepsize of subgradient of :math:`g^*`. This can be constant
         or function of iterations (in the latter cases provided as np.ndarray)
     y0 : :obj:`numpy.ndarray`

--- a/pyproximal/optimization/segmentation.py
+++ b/pyproximal/optimization/segmentation.py
@@ -29,7 +29,7 @@ def Segment(
 
     Parameters
     ----------
-    y : :obj:`np.ndarray`
+    y : :obj:`numpy.ndarray`
         Image to segment (must have 2 or more dimensions)
     cl : :obj:`numpy.ndarray`
         Classes

--- a/pyproximal/optimization/sr3.py
+++ b/pyproximal/optimization/sr3.py
@@ -41,7 +41,7 @@ def _lsqr(
         Data
     iter_lim: :obj:`int`
         Maximum number of iterations
-    z_old: :obj:`np.ndarray`
+    z_old: :obj:`numpy.ndarray`
         The previous outer iteration
     x0: :obj:`numpy.ndarray`
        initial guess
@@ -49,7 +49,7 @@ def _lsqr(
         The regularization parameter for the inner iteration
     eps: :obj:`float`
         The regularization parameter for the outer iteration
-    Reg: :obj:`np.ndarray`
+    Reg: :obj:`numpy.ndarray`
         The regularization operator L
 
     Returns

--- a/pyproximal/projection/Box.py
+++ b/pyproximal/projection/Box.py
@@ -8,9 +8,9 @@ class BoxProj:
 
     Parameters
     ----------
-    lower : :obj:`float` or :obj:`np.ndarray`, optional
+    lower : :obj:`float` or :obj:`numpy.ndarray`, optional
         Lower bound
-    upper : :obj:`float` or :obj:`np.ndarray`, optional
+    upper : :obj:`float` or :obj:`numpy.ndarray`, optional
         Upper bound
 
     Notes
@@ -56,13 +56,13 @@ class HyperPlaneBoxProj:
 
     Parameters
     ----------
-    coeffs : :obj:`np.ndarray`
+    coeffs : :obj:`numpy.ndarray`
         Vector of coefficients used in the definition of the hyperplane
     scalar : :obj:`float`
         Scalar used in the definition of the hyperplane
-    lower : :obj:`float` or :obj:`np.ndarray`, optional
+    lower : :obj:`float` or :obj:`numpy.ndarray`, optional
         Lower bound of Box
-    upper : :obj:`float` or :obj:`np.ndarray`, optional
+    upper : :obj:`float` or :obj:`numpy.ndarray`, optional
         Upper bound of Box
     maxiter : :obj:`int`, optional
         Maximum number of iterations used by :func:`scipy.optimize.bisect`
@@ -123,7 +123,7 @@ class HyperPlaneBoxProj:
 
         Parameters
         ----------
-        x : :obj:`np.ndarray`
+        x : :obj:`numpy.ndarray`
             Vector
 
         """

--- a/pyproximal/projection/Euclidean.py
+++ b/pyproximal/projection/Euclidean.py
@@ -7,7 +7,7 @@ class EuclideanBallProj:
 
     Parameters
     ----------
-    center : :obj:`np.ndarray` or :obj:`float`
+    center : :obj:`numpy.ndarray` or :obj:`float`
         Center of the ball
     radius : :obj:`float`
         Radius

--- a/pyproximal/projection/Intersection.py
+++ b/pyproximal/projection/Intersection.py
@@ -11,7 +11,7 @@ class IntersectionProj:
         Size of vector to be projected
     n : :obj:`int`
         Number of vectors to be projected simultaneously
-    sigma : :obj:`np.ndarray`
+    sigma : :obj:`numpy.ndarray`
         Matrix of distances of size :math:`k \times k`
     niter : :obj:`int`, optional
         Number of iterations

--- a/pyproximal/projection/Simplex.py
+++ b/pyproximal/projection/Simplex.py
@@ -45,7 +45,7 @@ class SimplexProj:
 
         Parameters
         ----------
-        x : :obj:`np.ndarray`
+        x : :obj:`numpy.ndarray`
             Vector
         maxiter : :obj:`int`, optional
             Maximum number of iterations used by :func:`scipy.optimize.bisect`

--- a/pyproximal/proximal/Box.py
+++ b/pyproximal/proximal/Box.py
@@ -12,9 +12,9 @@ class Box(ProxOperator):
 
     Parameters
     ----------
-    lower : :obj:`float` or :obj:`np.ndarray`, optional
+    lower : :obj:`float` or :obj:`numpy.ndarray`, optional
         Lower bound
-    upper : :obj:`float` or :obj:`np.ndarray`, optional
+    upper : :obj:`float` or :obj:`numpy.ndarray`, optional
         Upper bound
 
     Notes

--- a/pyproximal/proximal/Euclidean.py
+++ b/pyproximal/proximal/Euclidean.py
@@ -70,7 +70,7 @@ class EuclideanBall(ProxOperator):
 
     Parameters
     ----------
-    center : :obj:`np.ndarray` or :obj:`float`
+    center : :obj:`numpy.ndarray` or :obj:`float`
         Center of the ball
     radius : :obj:`float`
         Radius

--- a/pyproximal/proximal/Intersection.py
+++ b/pyproximal/proximal/Intersection.py
@@ -14,7 +14,7 @@ class Intersection(ProxOperator):
         Size of vector to be projected
     n : :obj:`int`
         Number of vectors to be projected simultaneously
-    sigma : :obj:`np.ndarray` or :obj:`float`
+    sigma : :obj:`numpy.ndarray` or :obj:`float`
         Matrix of distances of size :math:`k \times k` (or single value in the
         case of constant matrix)
     niter : :obj:`int`, optional

--- a/pyproximal/proximal/L0.py
+++ b/pyproximal/proximal/L0.py
@@ -58,7 +58,7 @@ class L0(ProxOperator):
 
     Parameters
     ----------
-    sigma : :obj:`float` or :obj:`np.ndarray` or :obj:`func`, optional
+    sigma : :obj:`float` or :obj:`numpy.ndarray` or :obj:`func`, optional
         Multiplicative coefficient of L0 norm. This can be a constant number, a list
         of values (for multidimensional inputs, acting on the second dimension) or
         a function that is called passing a counter which keeps track of how many

--- a/pyproximal/proximal/L1.py
+++ b/pyproximal/proximal/L1.py
@@ -60,13 +60,13 @@ class L1(ProxOperator):
 
     Parameters
     ----------
-    sigma : :obj:`float` or :obj:`np.ndarray` or :obj:`func`, optional
+    sigma : :obj:`float` or :obj:`numpy.ndarray` or :obj:`func`, optional
         Multiplicative coefficient of L1 norm. This can be a constant number, a list
         of values (for 2-dimensional inputs, acting on the second dimension) or
         a function that is called passing a counter which keeps track of how many
         times the ``prox`` method has been invoked before and returns a scalar (or a list of)
         ``sigma`` to be used.
-    g : :obj:`np.ndarray`, optional
+    g : :obj:`numpy.ndarray`, optional
         Vector to be subtracted
 
     Notes

--- a/pyproximal/proximal/L2.py
+++ b/pyproximal/proximal/L2.py
@@ -48,7 +48,7 @@ class L2(ProxOperator):
         This can be a constant number or a function that is called passing a
         counter which keeps track of how many times the ``prox`` method has
         been invoked before and returns the ``niter`` to be used.
-    x0 : :obj:`np.ndarray`, optional
+    x0 : :obj:`numpy.ndarray`, optional
         Initial vector
     warm : :obj:`bool`, optional
         Warm start (``True``) or not (``False``). Uses estimate from previous
@@ -316,7 +316,7 @@ class L2Convolve(ProxOperator):
 
     Parameters
     ----------
-    h : :obj:`np.ndarray`
+    h : :obj:`numpy.ndarray`
         Kernel of convolution operator
     b : :obj:`numpy.ndarray`
         Data vector

--- a/pyproximal/proximal/Nonlinear.py
+++ b/pyproximal/proximal/Nonlinear.py
@@ -29,7 +29,7 @@ class Nonlinear(ABC, ProxOperator):
 
     Parameters
     ----------
-    x0 : :obj:`np.ndarray`
+    x0 : :obj:`numpy.ndarray`
         Initial vector
     niter : :obj:`int`, optional
         Number of iterations of iterative scheme used to compute the proximal

--- a/pyproximal/proximal/Orthogonal.py
+++ b/pyproximal/proximal/Orthogonal.py
@@ -25,7 +25,7 @@ class Orthogonal(ProxOperator):
         Orthogonal operator
     partial : :obj:`bool`, optional
         Partial (``True``) of full (``False``) orthogonality
-    b : :obj:`np.ndarray`, optional
+    b : :obj:`numpy.ndarray`, optional
         Vector
     alpha : :obj:`float`, optional
         Positive coefficient for partial orthogonality. It will be ignored if

--- a/pyproximal/proximal/Quadratic.py
+++ b/pyproximal/proximal/Quadratic.py
@@ -22,13 +22,13 @@ class Quadratic(ProxOperator):
     ----------
     Op : :obj:`pylops.LinearOperator`, optional
         Linear operator (must be square)
-    b : :obj:`np.ndarray`, optional
+    b : :obj:`numpy.ndarray`, optional
         Vector
     c : :obj:`float`, optional
         Scalar
     niter : :obj:`int`, optional
         Number of iterations of iterative scheme used to compute the proximal
-    x0 : :obj:`np.ndarray`, optional
+    x0 : :obj:`numpy.ndarray`, optional
         Initial vector
     warm : :obj:`bool`, optional
         Warm start (``True``) or not (``False``). Uses estimate from previous
@@ -121,12 +121,12 @@ class Quadratic(ProxOperator):
 
         Parameters
         ----------
-        x : :obj:`np.ndarray`
+        x : :obj:`numpy.ndarray`
             Vector
 
         Returns
         -------
-        g : :obj:`np.ndarray`
+        g : :obj:`numpy.ndarray`
             Gradient vector
 
         """

--- a/pyproximal/proximal/RelaxedMS.py
+++ b/pyproximal/proximal/RelaxedMS.py
@@ -40,13 +40,13 @@ class RelaxedMumfordShah(ProxOperator):
 
     Parameters
     ----------
-    sigma : :obj:`float` or :obj:`np.ndarray` or :obj:`func`, optional
+    sigma : :obj:`float` or :obj:`numpy.ndarray` or :obj:`func`, optional
         Multiplicative coefficient of L2 norm that controls the smoothness of the solutuon.
         This can be a constant number, a list of values (for multidimensional inputs, acting
         on the second dimension) or a function that is called passing a counter which keeps
         track of how many times the ``prox`` method has been invoked before and returns a
         scalar (or a list of) ``sigma`` to be used.
-    kappa : :obj:`float` or :obj:`np.ndarray` or :obj:`func`, optional
+    kappa : :obj:`float` or :obj:`numpy.ndarray` or :obj:`func`, optional
         Constant value in the rMS norm which essentially controls when the norm allows a jump. This can be a
         constant number, a list of values (for multidimensional inputs, acting on the second dimension) or
         a function that is called passing a counter which keeps track of how many
@@ -58,10 +58,10 @@ class RelaxedMumfordShah(ProxOperator):
     The :math:`rMS` proximal operator is defined as [1]_:
 
     .. math::
-        \text{prox}_{\tau \text{rMS}}(x) =
+        \text{prox}_{\tau \text{rMS}}(\mathbf{x}) =
         \begin{cases}
-        \frac{1}{1+2\tau\alpha}x & \text{ if } & \vert x\vert \leq \sqrt{\frac{\kappa}{\alpha}(1 + 2\tau\alpha)} \\
-        \kappa & \text{ else }
+        \frac{1}{1+2\tau\alpha}x_i & \text{ if } & \vert x_i\vert \leq \sqrt{\frac{\kappa}{\alpha}(1 + 2\tau\alpha)} \\
+        x_i & \text{ else }
         \end{cases}.
 
     .. [1] Strekalovskiy, E., and D. Cremers, 2014, Real-time minimization of the piecewise smooth

--- a/pyproximal/proximal/Sum.py
+++ b/pyproximal/proximal/Sum.py
@@ -20,7 +20,7 @@ class Sum(ProxOperator):
     ----------
     ops : :obj:`list`
         A list of proximable functions :math:`f_1, \ldots, f_m`.
-    weights : :obj:`np.ndarray` or :obj:`list` or :obj:`None`, optional, default=None
+    weights : :obj:`numpy.ndarray` or :obj:`list` or :obj:`None`, optional, default=None
         Weights :math:`\sum_{i=1}^m w_i = 1, \ 0 < w_i < 1`,
         used when :math:`m > 2`, or :math:`m = 2` and ``use_parallel=True``.
         Defaults to None, which means :math:`w_1 = \cdots = w_m = \frac{1}{m}.`
@@ -142,7 +142,7 @@ class Sum(ProxOperator):
 
         Parameters
         ----------
-        x : :obj:`np.ndarray`
+        x : :obj:`numpy.ndarray`
             Vector
 
         Returns

--- a/pyproximal/proximal/_Simplex_cuda.py
+++ b/pyproximal/proximal/_Simplex_cuda.py
@@ -39,15 +39,15 @@ def simplex_jit_cuda(x, coeffs, scalar, lower, upper, maxiter, ftol, xtol, y):
 
     Parameters
     ----------
-    x : :obj:`np.ndarray`
+    x : :obj:`numpy.ndarray`
         Input vector
-    coeffs : :obj:`np.ndarray`
+    coeffs : :obj:`numpy.ndarray`
         Vector of coefficients used in the definition of the hyperplane
     scalar : :obj:`float`
         Scalar used in the definition of the hyperplane
-    lower : :obj:`float` or :obj:`np.ndarray`, optional
+    lower : :obj:`float` or :obj:`numpy.ndarray`, optional
         Lower bound of Box
-    upper : :obj:`float` or :obj:`np.ndarray`, optional
+    upper : :obj:`float` or :obj:`numpy.ndarray`, optional
         Upper bound of Box
     maxiter : :obj:`int`, optional
         Maximum number of iterations
@@ -55,7 +55,7 @@ def simplex_jit_cuda(x, coeffs, scalar, lower, upper, maxiter, ftol, xtol, y):
         Function tolerance
     xtol : :obj:`float`, optional
         Solution absolute tolerance
-    y : :obj:`np.ndarray`
+    y : :obj:`numpy.ndarray`
         Output vector
 
     """

--- a/pyproximal/proximal/_Simplex_numba.py
+++ b/pyproximal/proximal/_Simplex_numba.py
@@ -37,19 +37,19 @@ def bisect_jit(
 
     Parameters
     ----------
-    x : :obj:`np.ndarray`
+    x : :obj:`numpy.ndarray`
         Input vector
-    coeffs : :obj:`np.ndarray`
+    coeffs : :obj:`numpy.ndarray`
         Vector of coefficients used in the definition of the hyperplane
     scalar : :obj:`float`
         Scalar used in the definition of the hyperplane
-    lower : :obj:`float` or :obj:`np.ndarray`, optional
+    lower : :obj:`float` or :obj:`numpy.ndarray`, optional
         Lower bound of Box
-    upper : :obj:`float` or :obj:`np.ndarray`, optional
+    upper : :obj:`float` or :obj:`numpy.ndarray`, optional
         Upper bound of Box
-    bisect_lower : :obj:`float` or :obj:`np.ndarray`, optional
+    bisect_lower : :obj:`float` or :obj:`numpy.ndarray`, optional
         Lower end of bisection
-    bisect_upper : :obj:`float` or :obj:`np.ndarray`, optional
+    bisect_upper : :obj:`float` or :obj:`numpy.ndarray`, optional
         Upper end of bisection
     maxiter : :obj:`int`, optional
         Maximum number of iterations
@@ -91,15 +91,15 @@ def simplex_jit(
 
     Parameters
     ----------
-    x : :obj:`np.ndarray`
+    x : :obj:`numpy.ndarray`
         Input vector
-    coeffs : :obj:`np.ndarray`
+    coeffs : :obj:`numpy.ndarray`
         Vector of coefficients used in the definition of the hyperplane
     scalar : :obj:`float`
         Scalar used in the definition of the hyperplane
-    lower : :obj:`float` or :obj:`np.ndarray`, optional
+    lower : :obj:`float` or :obj:`numpy.ndarray`, optional
         Lower bound of Box
-    upper : :obj:`float` or :obj:`np.ndarray`, optional
+    upper : :obj:`float` or :obj:`numpy.ndarray`, optional
         Upper bound of Box
     maxiter : :obj:`int`, optional
         Maximum number of iterations

--- a/pyproximal/utils/moreau.py
+++ b/pyproximal/utils/moreau.py
@@ -25,7 +25,7 @@ def moreau(
     ----------
     prox : :obj:`pyproximal.ProxOperator`
         Proximal operator
-    x : :obj:`np.ndarray`
+    x : :obj:`numpy.ndarray`
         Vector
     tau : :obj:`float`
         Positive scalar weight


### PR DESCRIPTION
Minor doc improvements:

 - Fix prox equation in `RelaxedMumfordShah`.
 - Switch all `np.ndarray` to `numpy.ndarray` in docstrings.