### PR TITLE
Build: modernization of build process

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,9 +16,12 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     runs-on: ${{ matrix.platform }}
+
     steps:
       - name: Check out source repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - name: Install uv with Python ${{ matrix.python-version }}
         uses: astral-sh/setup-uv@v6
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,11 +17,8 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v4
-      - name: Get history and tags for SCM versioning to work
-        run: |
-          git fetch --prune --unshallow
-          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+      - name: Check out source repository
+        uses: actions/checkout@v4
       - name: Install uv with Python ${{ matrix.python-version }}
         uses: astral-sh/setup-uv@v6
         with:

--- a/.github/workflows/codacy-coverage-reporter.yaml
+++ b/.github/workflows/codacy-coverage-reporter.yaml
@@ -9,20 +9,16 @@ on:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        platform: [ubuntu-latest]
-        python-version: ["3.11"]
-
-    runs-on: ${{ matrix.platform }}
-
+    runs-on: ubuntu-latest
     steps:
       - name: Check out source repository
-        uses: actions/checkout@v4
-      - name: Install uv with Python ${{ matrix.python-version }}
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Install uv with Python
         uses: astral-sh/setup-uv@v6
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
       - name: Install dependencies and pyproximal
         run: uv sync --locked --all-extras --all-groups
       - name: Coverage with pytest

--- a/.github/workflows/codacy-coverage-reporter.yaml
+++ b/.github/workflows/codacy-coverage-reporter.yaml
@@ -17,33 +17,24 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Get history and tags for SCM versioning to work
-        run: |
-          git fetch --prune --unshallow
-          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-
+      - name: Check out source repository
+        uses: actions/checkout@v4
       - name: Install uv with Python ${{ matrix.python-version }}
         uses: astral-sh/setup-uv@v6
         with:
           python-version: ${{ matrix.python-version }}
-
       - name: Install dependencies and pyproximal
         run: uv sync --locked --all-extras --all-groups
-
       - name: Coverage with pytest
         run: |
           uv run coverage run -m pytest
           uv run coverage xml
           uv run coverage html
-
       - name: Upload HTML coverage report
         uses: actions/upload-artifact@v4
         with:
           name: coverage-html
           path: htmlcov/
-
       - name: Run codacy-coverage-reporter
         if: github.event_name == 'push'
         uses: codacy/codacy-coverage-reporter-action@v1

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,28 +1,67 @@
 # This workflow uploads PyProx on PyPI using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+# For more information see: https://github.com/python-attrs/attrs/blob/main/.github/workflows/pypi-package.yml
 name: PyProximal-deploy
 
 on:
+  push:
+    tags: ["*"]
   release:
-    types: [published]
+    types:
+      - published
+  workflow_dispatch:
 
 jobs:
-  deploy:
+  build-package:
+    name: Build & verify package
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v2
+      - name: Check out source repository
+        uses: actions/checkout@v6
         with:
-          python-version: '3.x'
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install build
-      - name: Build package
-        run: python -m build
-      - name: Publish package
-        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+          fetch-depth: 0
+      - name: Build and inspect package
+        uses: hynek/build-and-inspect-python-package@v2
+
+  release-test-pypi:
+    name: Publish in-dev package to test.pypi.org
+    if: github.repository_owner == 'PyLops' && github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    needs: build-package
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download package
+        uses: actions/download-artifact@v8
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          name: Packages
+          path: dist
+
+      - name: Upload package to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: true
+          repository-url: https://test.pypi.org/legacy/
+
+  release-pypi:
+    name: Publish released package to pypi.org
+    if: github.repository_owner == 'PyLops' && github.event.action == 'published'
+    runs-on: ubuntu-latest
+    needs: build-package
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download package
+        uses: actions/download-artifact@v8
+        with:
+          name: Packages
+          path: dist
+
+      - name: Upload package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: true

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -9,7 +9,9 @@ jobs:
     name: MyPy
     steps:
       - name: Check out source repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - name: Install uv with Python
         uses: astral-sh/setup-uv@v6
         with:

--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -10,8 +10,10 @@ jobs:
     name: Lint
     steps:
       - name: Check out source repository
-        uses: actions/checkout@v4
-      - name: ruff Lint
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Lint with ruff
         uses: astral-sh/ruff-action@v3
         with:
            src: "./pyproximal"

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ build
 dist
 pyproximal.egg-info/
 
-# setuptools_scm generated  #
+# hatchling generated  #
 pyproximal/version.py
 
 # Development #

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ UV := $(shell command -v uv 2> /dev/null || command which uv 2> /dev/null)
 NOX := $(shell command -v nox 2> /dev/null || command which nox 2> /dev/null)
 
 .PHONY: install_conda dev-install_conda dev-install_conda_arm dev-install_uv
-.PHONY: tests tests_uv tests_nox doc doc_uv docupdate docupdate_uv servedoc
+.PHONY: tests tests_uv tests_nox doc doc_uv docupdate docupdate_uv servedoc servedoc_uv
 .PHONY: lint lint_uv typeannot typeannot_uv coverage coverage_uv
 
 pipcheck:
@@ -57,7 +57,7 @@ tests_nox:
 	$(NOX) -s tests
 
 doc:
-	cd docs  && rm -rf source/api/generated && rm -rf source/gallery &&\
+	cd docs && rm -rf source/api/generated && rm -rf source/gallery &&\
 	rm -rf source/tutorials && rm -rf source/examples &&\
 	rm -rf build && make html && cd ..
 
@@ -68,6 +68,7 @@ doc_uv:
 	rm -rf build && $(UV) run make html && cd ..
 
 docupdate:
+	make pythoncheck
 	cd docs && make html && cd ..
 
 docupdate_uv:

--- a/README.md
+++ b/README.md
@@ -107,32 +107,36 @@ This repository is organized as follows:
 ## Getting started
 You need **Python 3.10 or greater**.
 
-#### From Conda
-
-To get the most out of PyLops straight out of the box, we recommend `conda` to install PyLops:
-```bash
-conda install -c conda-forge pyproximal
-```
-
 #### From PyPI
-You can also install pyproximal with `pip`:
-```bash
-pip install pyproximal
-```
-or via `uv`:
+To get the most out of PyProximal straight out of the box, we recommend using
+the PyPI distribution via `uv`:
+
 ```bash
 uv pip install pyproximal
 ```
 
-#### From Github
-Finally, you can also directly install from the main branch (although this is not recommended):
+or directly via `pip`:
 
+```bash
+pip install pyproximal
 ```
-pip install git+https://git@github.com/PyLops/pyproximal.git@main
+
+#### From Conda
+You can also install PyProximal via `conda`:
+
+```bash
+conda install -c conda-forge pyproximal
 ```
-or via `uv`:
+
+#### From Github
+Finally, you can also directly install from the main branch (although this is not recommended) via `uv`:
+
 ```bash
 uv add git+https://github.com/PyLops/pyproximal.git --branch main
+```
+or via `pip`:
+```bash
+pip install git+https://git@github.com/PyLops/pyproximal.git@main
 ```
 
 ## Contributing
@@ -150,8 +154,8 @@ Execute the following command in your terminal:
 git clone https://github.com/your_name_here/pyproximal.git
 ```
 
-### 2. Install PyLops in a new Conda environment
-To ensure that further development of PyLops is performed within the same environment (i.e.,
+### 2. Install PyProximal in a new Conda environment
+To ensure that further development of PyProximal is performed within the same environment (i.e.,
 same dependencies) as that defined by ``environment-dev.yml``/``environment-dev-arm.yml`` files,
 we suggest to work off a new Conda enviroment.
 

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -113,7 +113,7 @@ will also be run as part of our CI.
 
 .. tab-set::
 
-   .. tab-item::  conda
+   .. tab-item::  :iconify:`devicon:anaconda` conda
 
         .. code-block:: bash
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -5,7 +5,6 @@
 
 Dependencies
 ************
-
 The mandatory dependencies of PyProximal are limited to:
 
 * Python 3.10 or greater
@@ -54,10 +53,9 @@ First install `pyproximal` with your package manager of choice.
 
             >> uv add "pyproximal[advanced]"
 
-
 From Source
 ===========
-To access the latest source from github:
+To access the latest source from GitHub:
 
 .. tab-set::
 
@@ -89,7 +87,6 @@ Fork the `PyProximal repository <https://github.com/PyLops/pyproximal>`_ and clo
 
 Install dependencies
 ====================
-
 We recommend installing dependencies into a separate environment.
 For that end, we provide a `Makefile` with useful commands for setting up the environment.
 
@@ -178,7 +175,7 @@ At this point, the user must check the changes and then stage them before trying
 
 Final steps
 ===========
-PyLops does not enforce the use of a linter as a pre-commit hook, but we do highly encourage using one before submitting a Pull Request.
+PyProximal does not enforce the use of a linter as a pre-commit hook, but we do highly encourage using one before submitting a Pull Request.
 A properly configured linter (``ruff``) can be run with:
 
 .. tab-set::

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -37,8 +37,8 @@ First install `pyproximal` with your package manager of choice.
 
             >> conda install --channel conda-forge pyproximal
 
-        Most of the dependencies (all required and some of the optional) are
-        automatically installed for you.
+        which installs also the *required* dependencies, if not already present
+        in your environment.
 
    .. tab-item:: :iconify:`material-icon-theme:uv` uv
 
@@ -46,8 +46,8 @@ First install `pyproximal` with your package manager of choice.
 
             >> uv add pyproximal
         
-        Only the *required* dependencies are installed. To install
-        some of the optional dependencies, run:
+        which installs also the *required* dependencies, if not already present
+        in your environment. To also install the optional dependencies, run:
         
         .. code-block:: bash
 
@@ -79,7 +79,8 @@ Step-by-step installation for developers
 
 Fork PyProximal
 ===============
-Fork the `PyProximal repository <https://github.com/PyLops/pyproximal>`_ and clone it by executing the following in your terminal:
+Fork the `PyProximal repository <https://github.com/PyLops/pyproximal>`_ and clone it
+by executing the following in your terminal:
 
 .. code-block:: bash
 
@@ -175,8 +176,8 @@ At this point, the user must check the changes and then stage them before trying
 
 Final steps
 ===========
-PyProximal does not enforce the use of a linter as a pre-commit hook, but we do highly encourage using one before submitting a Pull Request.
-A properly configured linter (``ruff``) can be run with:
+PyProximal does enforce the use of a linter (``ruff``), which is run both as a pre-commit hook and as a GitHub Action.
+The linter can also be run locally with:
 
 .. tab-set::
 

--- a/environment-dev-arm.yml
+++ b/environment-dev-arm.yml
@@ -22,7 +22,6 @@ dependencies:
     - bm4d
     - bm3d
     - pytest-runner
-    - setuptools_scm
     - pooch
     - shibuya
     - sphinx-design

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -23,7 +23,6 @@ dependencies:
     - bm4d
     - bm3d
     - pytest-runner
-    - setuptools_scm
     - pooch
     - shibuya
     - sphinx-design

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,9 @@ build.hooks.vcs.version-file = "pyproximal/version.py"
 [tool.hatch.build.targets.wheel]
 packages = ["pyproximal"]
 
+[tool.hatch.build.targets.sdist]
+exclude = ["/.github", "/testdata"]
+
 [tool.pytest.ini_options]
 addopts = "--verbose"
 python_files = ["pytests/*.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,12 +75,12 @@ Documentation = "https://pyproximal.readthedocs.io/en/stable"
 Discussions = "https://github.com/PyLops/pyproximal/discussions"
 Issues = "https://github.com/PyLops/pyproximal/issues"
 
-[tool.hatch.build.targets.wheel]
-packages = ["pyproximal"]
-
 [tool.hatch]
 version.source = "vcs"
 build.hooks.vcs.version-file = "pyproximal/version.py"
+
+[tool.hatch.build.targets.wheel]
+packages = ["pyproximal"]
 
 [tool.pytest.ini_options]
 addopts = "--verbose"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,9 @@
 [build-system]
 requires = [
-    "setuptools >= 65",
-    "setuptools_scm[toml]",
-    "wheel",
+    "hatchling",
+    "hatch-vcs"
 ]
-build-backend = "setuptools.build_meta"
+build-backend = "hatchling.build"
 
 [project]
 name = "pyproximal"
@@ -70,11 +69,18 @@ doc = [
     "image",
 ]
 
-[tool.setuptools.packages.find]
-exclude = ["pytests"]
+[project.urls]
+Homepage = "https://github.com/PyLops/pyproximal"
+Documentation = "https://pyproximal.readthedocs.io/en/stable"
+Discussions = "https://github.com/PyLops/pyproximal/discussions"
+Issues = "https://github.com/PyLops/pyproximal/issues"
 
-[tool.setuptools_scm]
-version_file = "pyproximal/version.py"
+[tool.hatch.build.targets.wheel]
+packages = ["pyproximal"]
+
+[tool.hatch]
+version.source = "vcs"
+build.hooks.vcs.version-file = "pyproximal/version.py"
 
 [tool.pytest.ini_options]
 addopts = "--verbose"


### PR DESCRIPTION
This PR modernizes the build process of pyproximal by:

- [x] switching from `setuptool` to hatchling`
- [x] changing the `deploy.yaml` file to use Trusted Publisher Management (no more `secrets.PYPI_API_TOKEN`), and make an overall update based on https://github.com/PyLops/pyproximal/issues/242